### PR TITLE
Remove unused logging helpers

### DIFF
--- a/baseball_sim/gameplay/game.py
+++ b/baseball_sim/gameplay/game.py
@@ -25,7 +25,7 @@ from baseball_sim.gameplay.state import (
 from baseball_sim.prediction.batting import BattingModelLoader
 
 try:
-    from baseball_sim.infrastructure.logging_utils import GameStateError, logger
+    from baseball_sim.infrastructure.logging_utils import logger
 except ImportError:  # pragma: no cover - fallback for environments without infra module
     class logger:  # type: ignore
         @staticmethod
@@ -39,8 +39,6 @@ except ImportError:  # pragma: no cover - fallback for environments without infr
         @staticmethod
         def error(msg):
             print(f"ERROR: {msg}")
-
-    GameStateError = Exception  # type: ignore
 
 
 class GameState:

--- a/baseball_sim/infrastructure/logging_utils.py
+++ b/baseball_sim/infrastructure/logging_utils.py
@@ -1,11 +1,9 @@
-"""
-エラーハンドリングとロギング機能
-"""
+"""エラーハンドリングとロギング機能"""
+
 import logging
 import traceback
 from functools import wraps
-from pathlib import Path
-from typing import Any, Callable
+from typing import Callable
 
 from baseball_sim.config import get_project_paths
 
@@ -27,28 +25,10 @@ logging.basicConfig(
 
 logger = logging.getLogger('baseball_sim')
 
-class BaseballSimError(Exception):
-    """ベースボールシミュレーションの基底例外クラス"""
-    pass
-
-class GameStateError(BaseballSimError):
-    """ゲーム状態に関するエラー"""
-    pass
-
-class LineupError(BaseballSimError):
-    """ラインナップに関するエラー"""
-    pass
-
-class PlayerError(BaseballSimError):
-    """選手に関するエラー"""
-    pass
-
-class DataLoadError(BaseballSimError):
-    """データ読み込みに関するエラー"""
-    pass
 
 def log_error(func: Callable) -> Callable:
     """エラーログを記録するデコレータ"""
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:
@@ -57,52 +37,5 @@ def log_error(func: Callable) -> Callable:
             logger.error(f"Error in {func.__name__}: {str(e)}")
             logger.debug(traceback.format_exc())
             raise
+
     return wrapper
-
-def handle_exceptions(default_return: Any = None, 
-                     exception_types: tuple = (Exception,),
-                     log_level: str = "error") -> Callable:
-    """例外処理を行うデコレータ"""
-    def decorator(func: Callable) -> Callable:
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            try:
-                return func(*args, **kwargs)
-            except exception_types as e:
-                log_func = getattr(logger, log_level.lower(), logger.error)
-                log_func(f"Exception in {func.__name__}: {str(e)}")
-                return default_return
-        return wrapper
-    return decorator
-
-class ErrorReporter:
-    """エラーレポート機能"""
-    
-    @staticmethod
-    def report_validation_errors(errors: list, context: str = ""):
-        """バリデーションエラーを報告"""
-        if not errors:
-            return
-        
-        error_msg = f"Validation errors{f' in {context}' if context else ''}:"
-        logger.warning(error_msg)
-        for error in errors:
-            logger.warning(f"  - {error}")
-    
-    @staticmethod
-    def report_lineup_issues(team_name: str, issues: list):
-        """ラインナップの問題を報告"""
-        if not issues:
-            logger.info(f"Lineup for {team_name} is valid")
-            return
-        
-        logger.warning(f"Lineup issues for {team_name}:")
-        for issue in issues:
-            logger.warning(f"  - {issue}")
-    
-    @staticmethod
-    def report_game_state(game_state, action: str):
-        """ゲーム状態を報告"""
-        logger.info(f"{action}: Inning {game_state.inning}, "
-                   f"{'Top' if game_state.is_top_inning else 'Bottom'}, "
-                   f"Score: {game_state.away_score}-{game_state.home_score}")


### PR DESCRIPTION
## Summary
- remove unused custom exception classes and error reporter utilities from `logging_utils`
- simplify the logging import in the gameplay module now that the unused helpers are gone

## Testing
- python -m compileall baseball_sim

------
https://chatgpt.com/codex/tasks/task_e_68cffe66ac34832292a46b9830623ee8