### PR TITLE
Handle home plate outs on regular groundouts

### DIFF
--- a/baseball_sim/gameplay/utils.py
+++ b/baseball_sim/gameplay/utils.py
@@ -843,10 +843,17 @@ class RunnerEngine:
     def _handle_regular_groundout(self, batter) -> Tuple[int, str]:
         runs_scored = 0
         bases = self.game_state.bases
+        third_runner_out = False
+
         if bases[2] is not None and self.game_state.outs < 2:
             scoring_probability = 0.4
-            if random.random() < scoring_probability:
+            roll = random.random()
+            if roll < scoring_probability:
                 runs_scored += score_runner(bases, 2)
+            else:
+                clear_base(bases, 2)
+                self.game_state.add_out()
+                third_runner_out = True
         if bases[1] is not None and bases[2] is None:
             move_runner(bases, 1, 2)
         if bases[0] is not None and bases[1] is None:
@@ -854,6 +861,8 @@ class RunnerEngine:
         self.game_state.add_out()  # 打者アウト
         if runs_scored > 0:
             return runs_scored, f"Groundout. {runs_scored} run(s) scored!"
+        if third_runner_out:
+            return 0, "Groundout, runner out at home."
         return 0, "Groundout."
 
     # ---- フライアウト ----

--- a/baseball_sim/tests/test_runner_engine.py
+++ b/baseball_sim/tests/test_runner_engine.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+import types
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(PACKAGE_ROOT.parent))
+
+if 'baseball_sim' in sys.modules:
+    del sys.modules['baseball_sim']
+
+baseball_sim_stub = types.ModuleType('baseball_sim')
+baseball_sim_stub.__path__ = [str(PACKAGE_ROOT)]
+sys.modules['baseball_sim'] = baseball_sim_stub
+
+from baseball_sim.gameplay.state import BaseRunners
+from baseball_sim.gameplay.utils import RunnerEngine
+
+
+class DummyGameState:
+    def __init__(self, outs: int = 0):
+        self.outs = outs
+        self.bases = BaseRunners()
+
+    def add_out(self) -> None:
+        self.outs += 1
+
+
+def test_regular_groundout_runner_out_at_home(monkeypatch):
+    game_state = DummyGameState(outs=0)
+    game_state.bases[1] = "Runner2"
+    game_state.bases[2] = "Runner3"
+
+    engine = RunnerEngine(game_state)
+
+    monkeypatch.setattr("baseball_sim.gameplay.utils.random.random", lambda: 0.95)
+
+    runs, message = engine._handle_regular_groundout(batter=object())
+
+    assert runs == 0
+    assert message == "Groundout, runner out at home."
+    assert game_state.outs == 2
+    assert game_state.bases[2] == "Runner2"
+    assert game_state.bases[1] is None


### PR DESCRIPTION
## Summary
- treat failed third-base scoring attempts on regular grounders as outs at home, updating bases and outs
- return a descriptive message when the home-plate out occurs
- add a runner engine unit test covering the home-plate throwout scenario

## Testing
- pytest baseball_sim/tests/test_runner_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d00357559483228644e4a9cad4a7d1