### PR TITLE
Add extra base running outcomes for hit events

### DIFF
--- a/baseball_sim/gameplay/utils.py
+++ b/baseball_sim/gameplay/utils.py
@@ -641,16 +641,32 @@ class RunnerEngine:
             run_probability = 0.65
             run_probability *= (4.3 / batter.speed)
             if random.random() < run_probability:
-                runs += score_runner(bases, 1)
+                runner = bases[1]
+                runner_speed = getattr(runner, "speed", getattr(batter, "speed", 4.3))
+                success_probability = 0.8 * (4.3 / runner_speed)
+                success_probability = max(0.3, min(0.95, success_probability))
+                if random.random() < success_probability:
+                    runs += score_runner(bases, 1)
+                else:
+                    clear_base(bases, 1)
+                    self.game_state.add_out()
             else:
                 move_runner(bases, 1, 2)
 
         # 一塁走者の処理
         if bases[0] is not None:
+            runner = bases[0]
             advance_probability = 0.1
             advance_probability *= (4.3 / batter.speed)
             if bases[2] is None and random.random() < advance_probability:
-                move_runner(bases, 0, 2)
+                runner_speed = getattr(runner, "speed", getattr(batter, "speed", 4.3))
+                success_probability = 0.7 * (4.3 / runner_speed)
+                success_probability = max(0.25, min(0.9, success_probability))
+                if random.random() < success_probability:
+                    move_runner(bases, 0, 2)
+                else:
+                    clear_base(bases, 0)
+                    self.game_state.add_out()
             else:
                 move_runner(bases, 0, 1)
 
@@ -673,7 +689,15 @@ class RunnerEngine:
         if bases[0] is not None:
             run_probability = 0.2 * (4.3 / batter.speed)
             if random.random() < run_probability:
-                runs += score_runner(bases, 0)
+                runner = bases[0]
+                runner_speed = getattr(runner, "speed", getattr(batter, "speed", 4.3))
+                success_probability = 0.75 * (4.3 / runner_speed)
+                success_probability = max(0.35, min(0.98, success_probability))
+                if random.random() < success_probability:
+                    runs += score_runner(bases, 0)
+                else:
+                    clear_base(bases, 0)
+                    self.game_state.add_out()
             else:
                 move_runner(bases, 0, 2)
 
@@ -687,8 +711,21 @@ class RunnerEngine:
         """三塁打時のランナー進塁処理（得点数を返す）"""
         bases = self.game_state.bases
         runs = score_all_runners(bases)
-        # 打者は三塁へ
-        bases[2] = batter
+
+        batter_speed = getattr(batter, "speed", 4.3)
+        attempt_probability = 0.12 * (4.3 / batter_speed)
+        attempt_probability = max(0.05, min(0.3, attempt_probability))
+
+        if random.random() < attempt_probability:
+            success_probability = 0.55 * (4.3 / batter_speed)
+            success_probability = max(0.25, min(0.85, success_probability))
+            if random.random() < success_probability:
+                runs += 1
+            else:
+                self.game_state.add_out()
+        else:
+            # 打者は三塁へ
+            bases[2] = batter
         return runs
 
     # ---- 本塁打 ----

--- a/baseball_sim/tests/test_runner_engine.py
+++ b/baseball_sim/tests/test_runner_engine.py
@@ -1,4 +1,5 @@
 import sys
+from itertools import chain, repeat
 from pathlib import Path
 import types
 
@@ -25,6 +26,15 @@ class DummyGameState:
         self.outs += 1
 
 
+def make_random_sequence(*values):
+    sequence = chain(values, repeat(values[-1]))
+
+    def _random():
+        return next(sequence)
+
+    return _random
+
+
 def test_regular_groundout_runner_out_at_home(monkeypatch):
     game_state = DummyGameState(outs=0)
     game_state.bases[1] = "Runner2"
@@ -41,3 +51,62 @@ def test_regular_groundout_runner_out_at_home(monkeypatch):
     assert game_state.outs == 2
     assert game_state.bases[2] == "Runner2"
     assert game_state.bases[1] is None
+
+
+def test_apply_single_runner_thrown_out_attempting_third(monkeypatch):
+    game_state = DummyGameState()
+    runner = types.SimpleNamespace(speed=4.3)
+    batter = types.SimpleNamespace(speed=4.3)
+    game_state.bases[0] = runner
+
+    engine = RunnerEngine(game_state)
+    monkeypatch.setattr(
+        "baseball_sim.gameplay.utils.random.random",
+        make_random_sequence(0.05, 0.95),
+    )
+
+    runs = engine.apply_single(batter)
+
+    assert runs == 0
+    assert game_state.outs == 1
+    assert game_state.bases[0] == batter
+    assert game_state.bases[1] is None
+    assert game_state.bases[2] is None
+
+
+def test_apply_double_runner_scores_attempting_home(monkeypatch):
+    game_state = DummyGameState()
+    runner = types.SimpleNamespace(speed=4.3)
+    batter = types.SimpleNamespace(speed=4.3)
+    game_state.bases[0] = runner
+
+    engine = RunnerEngine(game_state)
+    monkeypatch.setattr(
+        "baseball_sim.gameplay.utils.random.random",
+        make_random_sequence(0.1, 0.05),
+    )
+
+    runs = engine.apply_double(batter)
+
+    assert runs == 1
+    assert game_state.outs == 0
+    assert game_state.bases[0] is None
+    assert game_state.bases[1] == batter
+    assert game_state.bases[2] is None
+
+
+def test_apply_triple_batter_scores_on_extra_base_attempt(monkeypatch):
+    game_state = DummyGameState()
+    batter = types.SimpleNamespace(speed=4.3)
+
+    engine = RunnerEngine(game_state)
+    monkeypatch.setattr(
+        "baseball_sim.gameplay.utils.random.random",
+        make_random_sequence(0.1, 0.1),
+    )
+
+    runs = engine.apply_triple(batter)
+
+    assert runs == 1
+    assert game_state.outs == 0
+    assert all(base is None for base in game_state.bases)


### PR DESCRIPTION
## Summary
- add extra base attempt handling and outs to RunnerEngine single and double logic
- allow triple results to include inside-the-park attempts with success or caught outcomes
- cover extra-base running success and failure scenarios in runner engine tests

## Testing
- pytest baseball_sim/tests/test_runner_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d00671649c8322b5ee047acf7694cb