### PR TITLE
Restore Manage Setup lineup button

### DIFF
--- a/baseball_sim/ui/gui/gui_constants.py
+++ b/baseball_sim/ui/gui/gui_constants.py
@@ -126,6 +126,7 @@ def get_ui_text():
         "team_manage_lineup": "Current Lineup",
         "team_manage_bench": "Bench",
         "team_manage_pitcher": "Starting Pitcher",
+        "team_manage_lineup_setup": "Lineup Setup",
         "team_manage_defense": "Edit Positions",
         "team_manage_order": "Swap Batting Order",
         "team_manage_pitcher_button": "Set Starting Pitcher",

--- a/baseball_sim/ui/gui/gui_main.py
+++ b/baseball_sim/ui/gui/gui_main.py
@@ -1349,6 +1349,24 @@ class BaseballGUI:
             status = self.team_manager.get_team_status(team_type)
             status_label.config(text=status['message'], foreground=status['color'])
 
+        def open_lineup_setup():
+            latest_team = self.team_manager.get_team_by_type(team_type)
+            if not latest_team:
+                messagebox.showinfo("Info", "Team is not ready yet.")
+                return
+            lineup_window = self.strategy_manager._show_lineup_setup_for_team(
+                latest_team,
+                refresh_callback=refresh_lists,
+                team_type=team_type
+            )
+            if lineup_window and lineup_window.winfo_exists():
+                try:
+                    self.root.wait_window(lineup_window)
+                except Exception:
+                    pass
+            refresh_lists()
+            self._update_title_screen_status()
+
         def open_defense_setup():
             substitution_manager = self.team_manager.get_substitution_manager(team_type)
             if not substitution_manager:
@@ -1368,6 +1386,7 @@ class BaseballGUI:
         def open_pitcher_dialog():
             self._open_pitcher_selection_dialog(team_type, dialog, refresh_lists)
 
+        ttk.Button(controls, text=self.text["team_manage_lineup_setup"], command=open_lineup_setup).pack(side=tk.LEFT, padx=4)
         ttk.Button(controls, text=self.text["team_manage_defense"], command=open_defense_setup).pack(side=tk.LEFT, padx=4)
         ttk.Button(controls, text=self.text["team_manage_order"], command=open_swap_dialog).pack(side=tk.LEFT, padx=4)
         ttk.Button(controls, text=self.text["team_manage_pitcher_button"], command=open_pitcher_dialog).pack(side=tk.LEFT, padx=4)


### PR DESCRIPTION
## Summary
- add back a Lineup Setup control to the Manage Setup dialog and wire it to the lineup setup window
- update the lineup setup workflow so changes refresh the Manage Setup display and fire LINEUP_CHANGED events

## Testing
- python -m compileall baseball_sim

------
https://chatgpt.com/codex/tasks/task_e_68d01b52c5cc832285c974668fda0702