### PR TITLE
Add infield fly logic with probability split

### DIFF
--- a/tests/test_runner_engine_flyout.py
+++ b/tests/test_runner_engine_flyout.py
@@ -60,7 +60,7 @@ def test_flyout_tagups_success(monkeypatch, batter):
     game_state.bases[1] = second_runner
     game_state.bases[0] = first_runner
 
-    set_random_sequence(monkeypatch, [0.0, 0.0, 0.0, 0.0])
+    set_random_sequence(monkeypatch, [0.5, 0.0, 0.0, 0.0, 0.0])
 
     runs = engine.apply_flyout(batter)
 
@@ -78,7 +78,7 @@ def test_flyout_tagup_runner_thrown_out(monkeypatch, batter):
     second_runner = SimpleNamespace(speed=4.3)
     game_state.bases[1] = second_runner
 
-    set_random_sequence(monkeypatch, [0.0, 0.99])
+    set_random_sequence(monkeypatch, [0.5, 0.0, 0.99])
 
     runs = engine.apply_flyout(batter)
 
@@ -96,7 +96,7 @@ def test_flyout_double_play_leave_early(monkeypatch, batter):
     game_state.bases[1] = second_runner
     game_state.bases[0] = first_runner
 
-    set_random_sequence(monkeypatch, [0.99, 0.0, 0.99, 0.0])
+    set_random_sequence(monkeypatch, [0.5, 0.99, 0.0, 0.99, 0.0])
 
     runs = engine.apply_flyout(batter)
 
@@ -105,3 +105,37 @@ def test_flyout_double_play_leave_early(monkeypatch, batter):
     assert game_state.bases[1] is None
     assert game_state.bases[0] is None
     assert game_state.add_out_calls == 2
+
+
+def test_infield_flyout_no_advancement(monkeypatch, batter):
+    game_state = DummyGameState()
+    engine = RunnerEngine(game_state)
+
+    first_runner = SimpleNamespace(speed=4.3)
+    game_state.bases[0] = first_runner
+
+    set_random_sequence(monkeypatch, [0.05, 0.5])
+
+    runs = engine.apply_flyout(batter)
+
+    assert runs == 0
+    assert game_state.outs == 0
+    assert game_state.bases[0] is first_runner
+    assert game_state.add_out_calls == 0
+
+
+def test_infield_flyout_double_off_lead_runner(monkeypatch, batter):
+    game_state = DummyGameState()
+    engine = RunnerEngine(game_state)
+
+    first_runner = SimpleNamespace(speed=4.3)
+    game_state.bases[0] = first_runner
+
+    set_random_sequence(monkeypatch, [0.05, 0.01])
+
+    runs = engine.apply_flyout(batter)
+
+    assert runs == 0
+    assert game_state.outs == 1
+    assert game_state.bases[0] is None
+    assert game_state.add_out_calls == 1


### PR DESCRIPTION
## Summary
- route 13% of fly outs through a newly added infield-fly handler while keeping the existing logic for outfield flies
- add small double-play chance for infield pop-ups and leave outfield processing untouched in a dedicated helper
- adjust flyout tests for the new random roll ordering and cover infield fly behaviour

## Testing
- pytest (fails: missing joblib and torch dependencies for prediction model tests)
- pytest tests/test_runner_engine_flyout.py

------
https://chatgpt.com/codex/tasks/task_e_68d0dd5f4bc083228037f4cd372d75e4