### PR TITLE
Split flyout probabilities into infield and outfield

### DIFF
--- a/baseball_sim/gameplay/outcomes/probability.py
+++ b/baseball_sim/gameplay/outcomes/probability.py
@@ -7,6 +7,7 @@ from typing import Dict, Optional
 from prediction_models.prediction import predict_auto
 
 _DEFAULT_MODEL_OUTPUT = [0.15, 0.05, 0.01, 0.03, 0.76]
+_INFIELD_FLY_RATIO = 0.13
 
 
 @dataclass
@@ -46,6 +47,8 @@ class OutcomeProbabilityCalculator:
 
         groundout_prob = out_woSO_prob * gb_prob
         flyout_prob = max(0.0, out_woSO_prob - groundout_prob)
+        infield_flyout_prob = flyout_prob * _INFIELD_FLY_RATIO
+        outfield_flyout_prob = max(0.0, flyout_prob - infield_flyout_prob)
 
         return {
             "strikeout": k_prob,
@@ -55,7 +58,8 @@ class OutcomeProbabilityCalculator:
             "triple": triple_prob,
             "home_run": hr_prob,
             "groundout": groundout_prob,
-            "flyout": flyout_prob,
+            "infield_flyout": infield_flyout_prob,
+            "outfield_flyout": outfield_flyout_prob,
         }
 
     def _calculate_component(self, batter_value: float, pitcher_value: float, league_average: float) -> float:

--- a/baseball_sim/gameplay/utils.py
+++ b/baseball_sim/gameplay/utils.py
@@ -910,13 +910,15 @@ class RunnerEngine:
         return 0, "Groundout."
 
     # ---- フライアウト ----
-    def apply_flyout(self, batter) -> int:
-        """フライアウト時の進塁・得点処理（得点数を返す）。"""
+    def apply_outfield_flyout(self, batter) -> int:
+        """外野フライ時の進塁・得点処理（得点数を返す）。"""
 
-        fly_ball_roll = random.random()
-        if fly_ball_roll < 0.13:
-            return self._handle_infield_flyout(batter)
         return self._handle_outfield_flyout(batter)
+
+    def apply_infield_flyout(self, batter) -> int:
+        """内野フライ時の進塁・得点処理（得点数を返す）。"""
+
+        return self._handle_infield_flyout(batter)
 
     def _handle_outfield_flyout(self, batter) -> int:
         """外野フライ時のタッチアップ処理と得点計算。"""

--- a/baseball_sim/ui/gui/gui_field.py
+++ b/baseball_sim/ui/gui/gui_field.py
@@ -217,7 +217,15 @@ class FieldManager:
         )
         
         # 結果に応じてアニメーション
-        if result in ["single", "double", "triple", "home_run", "groundout", "flyout"]:
+        if result in [
+            "single",
+            "double",
+            "triple",
+            "home_run",
+            "groundout",
+            "outfield_flyout",
+            "infield_flyout",
+        ]:
             # ヒットやアウトの場合のボール軌道
             if result == "single":
                 steps = 100
@@ -234,7 +242,7 @@ class FieldManager:
             elif result == "groundout":
                 steps = 100
                 speed = 1.9
-            elif result == "flyout":
+            elif result in ("outfield_flyout", "infield_flyout"):
                 steps = 130
                 speed = 2.5
             rad = math.radians(random.uniform(45, 135))

--- a/tests/test_runner_engine_flyout.py
+++ b/tests/test_runner_engine_flyout.py
@@ -60,9 +60,9 @@ def test_flyout_tagups_success(monkeypatch, batter):
     game_state.bases[1] = second_runner
     game_state.bases[0] = first_runner
 
-    set_random_sequence(monkeypatch, [0.5, 0.0, 0.0, 0.0, 0.0])
+    set_random_sequence(monkeypatch, [0.0, 0.0, 0.0, 0.0])
 
-    runs = engine.apply_flyout(batter)
+    runs = engine.apply_outfield_flyout(batter)
 
     assert runs == 0
     assert game_state.outs == 0
@@ -78,9 +78,9 @@ def test_flyout_tagup_runner_thrown_out(monkeypatch, batter):
     second_runner = SimpleNamespace(speed=4.3)
     game_state.bases[1] = second_runner
 
-    set_random_sequence(monkeypatch, [0.5, 0.0, 0.99])
+    set_random_sequence(monkeypatch, [0.0, 0.99])
 
-    runs = engine.apply_flyout(batter)
+    runs = engine.apply_outfield_flyout(batter)
 
     assert runs == 0
     assert game_state.outs == 1
@@ -96,9 +96,9 @@ def test_flyout_double_play_leave_early(monkeypatch, batter):
     game_state.bases[1] = second_runner
     game_state.bases[0] = first_runner
 
-    set_random_sequence(monkeypatch, [0.5, 0.99, 0.0, 0.99, 0.0])
+    set_random_sequence(monkeypatch, [0.99, 0.0, 0.99, 0.0])
 
-    runs = engine.apply_flyout(batter)
+    runs = engine.apply_outfield_flyout(batter)
 
     assert runs == 0
     assert game_state.outs == 2
@@ -114,9 +114,9 @@ def test_infield_flyout_no_advancement(monkeypatch, batter):
     first_runner = SimpleNamespace(speed=4.3)
     game_state.bases[0] = first_runner
 
-    set_random_sequence(monkeypatch, [0.05, 0.5])
+    set_random_sequence(monkeypatch, [0.5])
 
-    runs = engine.apply_flyout(batter)
+    runs = engine.apply_infield_flyout(batter)
 
     assert runs == 0
     assert game_state.outs == 0
@@ -131,9 +131,9 @@ def test_infield_flyout_double_off_lead_runner(monkeypatch, batter):
     first_runner = SimpleNamespace(speed=4.3)
     game_state.bases[0] = first_runner
 
-    set_random_sequence(monkeypatch, [0.05, 0.01])
+    set_random_sequence(monkeypatch, [0.01])
 
-    runs = engine.apply_flyout(batter)
+    runs = engine.apply_infield_flyout(batter)
 
     assert runs == 0
     assert game_state.outs == 1


### PR DESCRIPTION
## Summary
- return separate infield and outfield fly probabilities from the outcome calculator
- route new flyout results through dedicated runner-engine handlers and GUI animations
- update targeted runner-engine flyout tests for the refactored API

## Testing
- pytest tests/test_runner_engine_flyout.py

------
https://chatgpt.com/codex/tasks/task_e_68d0e00d1b148322a1c3cd067ce1ef65