### PR TITLE
Keep batter strikeout stats in sync for legacy K key

### DIFF
--- a/baseball_sim/data/player.py
+++ b/baseball_sim/data/player.py
@@ -30,6 +30,7 @@ class Player:
             StatColumns.HOME_RUNS: 0,
             StatColumns.WALKS: 0,
             StatColumns.STRIKEOUTS: 0,
+            "K": 0,  # 旧来のキー名との互換性確保
             StatColumns.RUNS_BATTED_IN: 0
         }
 

--- a/baseball_sim/gameplay/outcomes/handler.py
+++ b/baseball_sim/gameplay/outcomes/handler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Callable, Dict
 
+from baseball_sim.gameplay.statistics import StatsCalculator
 from baseball_sim.gameplay.utils import RunnerEngine
 
 
@@ -35,8 +36,8 @@ class AtBatOutcomeHandler:
         pitcher = self._game_state.fielding_team.current_pitcher
         pitcher.pitching_stats["IP"] += 1 / 3
         batter.stats["AB"] += 1
-        batter.stats["SO"] += 1
-        pitcher.pitching_stats["SO"] += 1
+        StatsCalculator.record_strikeout(batter.stats)
+        StatsCalculator.record_strikeout(pitcher.pitching_stats)
         self._game_state.add_out()
         return "Strike out"
 

--- a/baseball_sim/gameplay/statistics.py
+++ b/baseball_sim/gameplay/statistics.py
@@ -57,18 +57,26 @@ class StatsCalculator:
     def calculate_hr_per_9(home_runs, innings_pitched):
         """HR/9計算（統一処理）"""
         return (home_runs * 9) / innings_pitched if innings_pitched > 0 else 0.00
-    
+
+    @staticmethod
+    def record_strikeout(stats):
+        """記録上の三振数を更新し、SOと旧来のKキーを同期させる"""
+        current = stats.get("SO", stats.get("K", 0)) + 1
+        stats["SO"] = current
+        stats["K"] = current
+        return current
+
     @staticmethod
     def update_player_stats(player, outcome, runs_scored=0, rbis=0):
         """プレイヤー統計更新（統一処理）"""
         stats = player.stats
         stats['AB'] = stats.get('AB', 0) + 1
-        
+
         if outcome in ['single', 'double', 'triple', 'home_run']:
             outcome_key = {'single': '1B', 'double': '2B', 'triple': '3B', 'home_run': 'HR'}[outcome]
             stats[outcome_key] = stats.get(outcome_key, 0) + 1
         elif outcome == 'strikeout':
-            stats['K'] = stats.get('K', 0) + 1
+            StatsCalculator.record_strikeout(stats)
         elif outcome == 'walk':
             stats['BB'] = stats.get('BB', 0) + 1
             stats['AB'] = stats.get('AB') - 1  # 四球は打数に含まれない

--- a/baseball_sim/ui/gui/gui_stats.py
+++ b/baseball_sim/ui/gui/gui_stats.py
@@ -108,7 +108,7 @@ class StatsManager:
             player.stats.get("R", 0),   # 得点
             player.stats.get("RBI", 0), # 打点
             player.stats.get("BB", 0),  # 四球
-            player.stats.get("K", 0),   # 三振
+            player.stats.get("SO", player.stats.get("K", 0)),   # 三振（SO優先、互換性確保）
             avg                         # 打率
         ]
         

--- a/tests/test_stats_strikeouts.py
+++ b/tests/test_stats_strikeouts.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _ensure_package_stub() -> None:
+    """Mirror the stub logic used in other tests to avoid heavy optional deps."""
+    package_name = "baseball_sim"
+    if package_name in sys.modules:
+        return
+
+    package_path = Path(__file__).resolve().parents[1] / package_name
+    stub = ModuleType(package_name)
+    stub.__path__ = [str(package_path)]  # type: ignore[attr-defined]
+    sys.modules[package_name] = stub
+
+
+_ensure_package_stub()
+
+from baseball_sim.data.player import Player
+from baseball_sim.gameplay.statistics import StatsCalculator
+
+
+def make_player():
+    return Player(
+        name="Test Player",
+        eligible_positions=["CF"],
+        k_pct=20,
+        bb_pct=10,
+        hard_pct=30,
+        speed=4.3,
+        gb_pct=45,
+        fielding_skill=50,
+    )
+
+
+def test_record_strikeout_syncs_so_and_k_keys():
+    player = make_player()
+
+    StatsCalculator.record_strikeout(player.stats)
+
+    assert player.stats["SO"] == 1
+    assert player.stats["K"] == 1
+
+
+def test_record_strikeout_handles_legacy_k_only_dict():
+    stats = {"K": 2}
+
+    StatsCalculator.record_strikeout(stats)
+
+    assert stats["SO"] == 3
+    assert stats["K"] == 3


### PR DESCRIPTION
## Summary
- add the legacy "K" key to each batter stat block and provide a helper that keeps it synchronized with the tracked SO count
- call the new helper from the strikeout handler so batter and pitcher totals update both keys together
- add unit coverage that exercises the aliasing logic, including legacy data containing only a K entry

## Testing
- pytest tests/test_stats_strikeouts.py
- pytest *(fails: ModuleNotFoundError: No module named 'joblib'; No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68d0ecd145c08322aae4ae87e2db2f07