### PR TITLE
Add startup mode selector and simulation UI

### DIFF
--- a/baseball_sim/interface/modes.py
+++ b/baseball_sim/interface/modes.py
@@ -1,46 +1,28 @@
 """Game mode selection and execution helpers."""
 
 import sys
-from typing import Optional
 
 from baseball_sim.config import setup_project_environment
-from baseball_sim.interface.simulation import simulate_games
 from baseball_sim.ui.gui.gui_app import BaseballApp
+from baseball_sim.ui.gui.gui_startup import SimulationWindow, StartupWindow
 
 setup_project_environment()
 
 
 class GameModeManager:
     """ゲームモードの選択と実行を管理するクラス"""
-    
-    MODES = {
-        "1": "gui",
-        "2": "simulation",
-        "0": None
-    }
-    
-    @staticmethod
-    def display_mode_selection() -> None:
-        """モード選択画面を表示"""
-        print("========== 野球シミュレーションモード選択 ==========")
-        print("1: GUIモード - グラフィカルインターフェース (スタメン設定可能)")
-        print("2: シミュレーションモード - 複数試合の自動シミュレーション")
-        print("0: 終了")
-    
-    @classmethod
-    def get_game_mode_choice(cls) -> Optional[str]:
-        """ユーザーからゲームモードの選択を取得"""
-        cls.display_mode_selection()
-        choice = input("実行するモードを選択してください (0-2): ")
 
-        mode = cls.MODES.get(choice)
-        if mode is None and choice == "0":
-            print("プログラムを終了します")
+    VALID_MODES = {"gui", "simulation"}
+
+    @classmethod
+    def get_game_mode_choice(cls) -> str:
+        """モード選択ウィンドウを表示して選択されたモードを返す"""
+        selector = StartupWindow()
+        mode = selector.show()
+
+        if mode not in cls.VALID_MODES:
             sys.exit(0)
-        elif mode is None:
-            print("無効な選択です。デフォルトのGUIモードで起動します")
-            mode = "gui"
-        
+
         return mode
     
     @staticmethod
@@ -60,11 +42,9 @@ class GameModeManager:
     @staticmethod
     def play_simulation_mode():
         """シミュレーションモードの実行"""
-        num_games = int(input("シミュレーションする試合数を入力してください: "))
-        output_file = input("結果を出力するファイル名を入力してください (デフォルト: タイムスタンプ付きファイル): ")
-        if not output_file.strip():
-            output_file = None  # Noneを渡すことでsimulate_games内でタイムスタンプ付きファイル名を生成
-        return simulate_games(num_games, output_file)
+        window = SimulationWindow()
+        window.show()
+        return None
     
     @classmethod
     def execute_game_mode(cls, mode: str):

--- a/baseball_sim/interface/simulation.py
+++ b/baseball_sim/interface/simulation.py
@@ -7,7 +7,7 @@ from baseball_sim.gameplay.statistics import StatsCalculator
 
 setup_project_environment()
 
-def simulate_games(num_games=10, output_file=None):
+def simulate_games(num_games=10, output_file=None, progress_callback=None, message_callback=None):
     """指定された回数の試合をシミュレーションし、結果をファイルに出力する"""
     # データローダーを直接インポート
     from baseball_sim.data.loader import DataLoader
@@ -19,6 +19,11 @@ def simulate_games(num_games=10, output_file=None):
         output_dir = os.path.join(project_root, "simulation_results")
         os.makedirs(output_dir, exist_ok=True)
         output_file = os.path.join(output_dir, f"simulation_results_{timestamp}.txt")
+
+    if message_callback:
+        message_callback(f"結果は {output_file} に保存されます。")
+    else:
+        print(f"結果は {output_file} に保存されます。")
     
     # 結果を保存するデータ構造を初期化
     results = {
@@ -41,7 +46,10 @@ def simulate_games(num_games=10, output_file=None):
             results["pitchers"][pitcher.name] = pitcher
     
     for game_num in range(1, num_games + 1):
-        print(f"シミュレーション中... 試合 {game_num}/{num_games}")
+        if message_callback:
+            message_callback(f"シミュレーション中... 試合 {game_num}/{num_games}")
+        else:
+            print(f"シミュレーション中... 試合 {game_num}/{num_games}")
         
         # 試合前にチームと選手の状態をリセット
         reset_team_and_players(home_team, away_team)
@@ -57,11 +65,23 @@ def simulate_games(num_games=10, output_file=None):
         
         # チームの勝敗統計を更新
         update_statistics(results, game, game_result)
+
+        if progress_callback:
+            progress_callback(game_num, num_games)
+        if message_callback:
+            message_callback(f"試合 {game_num}/{num_games} が完了しました。")
     
     # 結果をファイルに出力
     output_results(results, output_file)
-    print(f"シミュレーション完了。結果は {output_file} に保存されました。")
-    
+
+    results["output_file"] = output_file
+
+    completion_message = f"シミュレーション完了。結果は {output_file} に保存されました。"
+    if message_callback:
+        message_callback(completion_message)
+    else:
+        print(completion_message)
+
     return results
 
 def reset_team_and_players(home_team, away_team):

--- a/baseball_sim/ui/gui/gui_startup.py
+++ b/baseball_sim/ui/gui/gui_startup.py
@@ -1,0 +1,311 @@
+"""GUI components for selecting modes and running simulations."""
+
+import queue
+import threading
+import tkinter as tk
+from tkinter import messagebox, ttk
+from typing import Optional
+
+from baseball_sim.config import setup_project_environment
+from baseball_sim.interface.simulation import simulate_games
+
+setup_project_environment()
+
+
+class StartupWindow:
+    """アプリ起動時にモード選択を行うウィンドウ"""
+
+    def __init__(self):
+        self.root = tk.Tk()
+        self.root.title("Baseball Simulation - モード選択")
+        self.root.geometry("400x260")
+        self.root.resizable(False, False)
+
+        self.selected_mode = None
+
+        self._build_widgets()
+        self.root.protocol("WM_DELETE_WINDOW", self._on_close)
+
+    def _build_widgets(self) -> None:
+        """モード選択画面のウィジェットを構築"""
+        main_frame = ttk.Frame(self.root, padding=20)
+        main_frame.pack(fill="both", expand=True)
+
+        title_label = ttk.Label(
+            main_frame,
+            text="ベースボールシミュレーターへようこそ",
+            font=("Helvetica", 14, "bold"),
+            anchor="center"
+        )
+        title_label.pack(pady=(0, 10))
+
+        description = ttk.Label(
+            main_frame,
+            text="起動するモードを選択してください。",
+            anchor="center"
+        )
+        description.pack(pady=(0, 20))
+
+        gui_button = ttk.Button(
+            main_frame,
+            text="GUIモード (チーム編成＆試合)",
+            command=lambda: self._select_mode("gui")
+        )
+        gui_button.pack(fill="x", pady=5)
+
+        simulation_button = ttk.Button(
+            main_frame,
+            text="シミュレーションモード (自動試合)",
+            command=lambda: self._select_mode("simulation")
+        )
+        simulation_button.pack(fill="x", pady=5)
+
+        exit_button = ttk.Button(
+            main_frame,
+            text="終了",
+            command=self._on_close
+        )
+        exit_button.pack(fill="x", pady=(20, 0))
+
+    def _select_mode(self, mode: str) -> None:
+        """モードを選択しメインループを終了"""
+        self.selected_mode = mode
+        self.root.quit()
+
+    def _on_close(self) -> None:
+        """ウィンドウを閉じる際の処理"""
+        self.selected_mode = None
+        self.root.quit()
+
+    def show(self):
+        """ウィンドウを表示し、選択されたモードを返す"""
+        self.root.mainloop()
+        self.root.destroy()
+        return self.selected_mode
+
+
+class SimulationWindow:
+    """シミュレーションモードの操作と進捗表示を行うウィンドウ"""
+
+    POLL_INTERVAL_MS = 100
+
+    def __init__(self):
+        self.root = tk.Tk()
+        self.root.title("Baseball Simulation - シミュレーション")
+        self.root.geometry("640x520")
+
+        self.progress_queue = queue.Queue()
+        self.simulation_thread = None
+        self.is_running = False
+        self.last_results = None
+        self.total_games = 0
+
+        self.num_games_var = tk.StringVar(value="10")
+        self.output_file_var = tk.StringVar()
+        self.progress_label_var = tk.StringVar(value="0 / 0 試合")
+        self.status_var = tk.StringVar(value="シミュレーション待機中")
+
+        self._build_widgets()
+
+        self.root.protocol("WM_DELETE_WINDOW", self._on_close)
+        try:
+            if self.root.winfo_exists():
+                self.root.after(self.POLL_INTERVAL_MS, self._process_queue)
+        except tk.TclError:
+            pass
+
+    def _build_widgets(self) -> None:
+        """シミュレーションウィンドウのウィジェット構築"""
+        main_frame = ttk.Frame(self.root, padding=20)
+        main_frame.pack(fill="both", expand=True)
+
+        settings_frame = ttk.LabelFrame(main_frame, text="シミュレーション設定", padding=15)
+        settings_frame.pack(fill="x")
+
+        ttk.Label(settings_frame, text="試合数:").grid(row=0, column=0, sticky="w")
+        self.games_entry = ttk.Entry(settings_frame, textvariable=self.num_games_var, width=10)
+        self.games_entry.grid(row=0, column=1, sticky="w", padx=(5, 0))
+
+        ttk.Label(settings_frame, text="出力ファイル名:\n(空欄の場合は自動生成)").grid(
+            row=1, column=0, sticky="nw", pady=(10, 0)
+        )
+        self.output_entry = ttk.Entry(settings_frame, textvariable=self.output_file_var)
+        self.output_entry.grid(row=1, column=1, sticky="we", padx=(5, 0), pady=(10, 0))
+
+        settings_frame.columnconfigure(1, weight=1)
+
+        button_frame = ttk.Frame(main_frame)
+        button_frame.pack(fill="x", pady=(15, 0))
+
+        self.start_button = ttk.Button(button_frame, text="シミュレーション開始", command=self._start_simulation)
+        self.start_button.pack(side="left")
+
+        self.close_button = ttk.Button(button_frame, text="閉じる", command=self._on_close)
+        self.close_button.pack(side="right")
+
+        progress_frame = ttk.LabelFrame(main_frame, text="進捗", padding=15)
+        progress_frame.pack(fill="x", pady=(15, 0))
+
+        self.progress_bar = ttk.Progressbar(progress_frame, maximum=1, value=0)
+        self.progress_bar.pack(fill="x")
+
+        progress_label = ttk.Label(progress_frame, textvariable=self.progress_label_var, anchor="e")
+        progress_label.pack(fill="x", pady=(5, 0))
+
+        status_label = ttk.Label(main_frame, textvariable=self.status_var, foreground="#333333")
+        status_label.pack(fill="x", pady=(15, 0))
+
+        log_frame = ttk.LabelFrame(main_frame, text="進行ログ", padding=10)
+        log_frame.pack(fill="both", expand=True, pady=(15, 0))
+
+        self.log_text = tk.Text(log_frame, height=12, state="disabled", wrap="word")
+        self.log_text.pack(side="left", fill="both", expand=True)
+
+        scrollbar = ttk.Scrollbar(log_frame, orient="vertical", command=self.log_text.yview)
+        scrollbar.pack(side="right", fill="y")
+        self.log_text.configure(yscrollcommand=scrollbar.set)
+
+    def _start_simulation(self) -> None:
+        """シミュレーションを開始"""
+        if self.is_running:
+            return
+
+        try:
+            num_games = int(self.num_games_var.get())
+            if num_games <= 0:
+                raise ValueError
+        except ValueError:
+            messagebox.showerror("入力エラー", "試合数には1以上の整数を入力してください。")
+            return
+
+        output_file = self.output_file_var.get().strip() or None
+
+        self.total_games = num_games
+        self.progress_bar.config(maximum=num_games)
+        self.progress_bar["value"] = 0
+        self.progress_label_var.set(f"0 / {num_games} 試合")
+        self.status_var.set("シミュレーション準備中...")
+        self._append_log(f"{num_games}試合のシミュレーションを開始します。")
+
+        self.games_entry.config(state=tk.DISABLED)
+        self.output_entry.config(state=tk.DISABLED)
+        self.start_button.config(state=tk.DISABLED)
+        self.close_button.config(state=tk.DISABLED)
+        self.is_running = True
+
+        self.simulation_thread = threading.Thread(
+            target=self._run_simulation,
+            args=(num_games, output_file),
+            daemon=True,
+        )
+        self.simulation_thread.start()
+
+    def _run_simulation(self, num_games: int, output_file: Optional[str]) -> None:
+        """シミュレーションを別スレッドで実行"""
+        try:
+            results = simulate_games(
+                num_games=num_games,
+                output_file=output_file,
+                progress_callback=self._enqueue_progress,
+                message_callback=self._enqueue_message,
+            )
+            self.progress_queue.put(("completed", results))
+        except Exception as exc:  # pylint: disable=broad-except
+            self.progress_queue.put(("error", str(exc)))
+
+    def _enqueue_progress(self, current: int, total: int) -> None:
+        """進捗更新をキューに送信"""
+        self.progress_queue.put(("progress", current, total))
+
+    def _enqueue_message(self, message: str) -> None:
+        """メッセージ更新をキューに送信"""
+        self.progress_queue.put(("message", message))
+
+    def _process_queue(self) -> None:
+        """バックグラウンド処理からのメッセージをUIに反映"""
+        try:
+            while True:
+                item = self.progress_queue.get_nowait()
+                event_type = item[0]
+
+                if event_type == "progress":
+                    _, current, total = item
+                    self.progress_bar.config(maximum=max(total, 1))
+                    self.progress_bar["value"] = current
+                    self.progress_label_var.set(f"{current} / {total} 試合")
+                elif event_type == "message":
+                    _, message = item
+                    self.status_var.set(message)
+                    self._append_log(message)
+                elif event_type == "completed":
+                    _, results = item
+                    self._on_simulation_complete(results)
+                elif event_type == "error":
+                    _, error_message = item
+                    self._on_simulation_error(error_message)
+        except queue.Empty:
+            pass
+
+        try:
+            if self.root.winfo_exists():
+                self.root.after(self.POLL_INTERVAL_MS, self._process_queue)
+        except tk.TclError:
+            pass
+
+    def _on_simulation_complete(self, results):
+        """シミュレーション完了時の処理"""
+        self.is_running = False
+        self.last_results = results
+
+        self.games_entry.config(state=tk.NORMAL)
+        self.output_entry.config(state=tk.NORMAL)
+        self.start_button.config(state=tk.NORMAL)
+        self.close_button.config(state=tk.NORMAL)
+
+        output_path = results.get("output_file") if isinstance(results, dict) else None
+        if output_path:
+            completion_message = f"シミュレーション完了: {output_path}"
+        else:
+            completion_message = "シミュレーションが完了しました。"
+
+        if self.status_var.get() != completion_message:
+            self.status_var.set(completion_message)
+            self._append_log(completion_message)
+
+        messagebox.showinfo("完了", completion_message)
+
+    def _on_simulation_error(self, error_message: str) -> None:
+        """エラー発生時の処理"""
+        self.is_running = False
+
+        self.games_entry.config(state=tk.NORMAL)
+        self.output_entry.config(state=tk.NORMAL)
+        self.start_button.config(state=tk.NORMAL)
+        self.close_button.config(state=tk.NORMAL)
+
+        self.status_var.set(f"エラー: {error_message}")
+        self._append_log(f"エラー: {error_message}")
+        messagebox.showerror("エラー", error_message)
+
+    def _append_log(self, message: str) -> None:
+        """ログエリアにメッセージを追加"""
+        self.log_text.configure(state="normal")
+        self.log_text.insert("end", message + "\n")
+        self.log_text.see("end")
+        self.log_text.configure(state="disabled")
+
+    def _on_close(self) -> None:
+        """ウィンドウを閉じる"""
+        if self.is_running:
+            messagebox.showwarning("シミュレーション中", "シミュレーション終了までお待ちください。")
+            return
+
+        self.root.destroy()
+
+    def show(self):
+        """ウィンドウを表示"""
+        self.root.mainloop()
+        return self.last_results
+
+
+__all__ = ["StartupWindow", "SimulationWindow"]


### PR DESCRIPTION
## Summary
- replace the CLI-based mode selection with a Tkinter startup window
- add a simulation controller window that captures settings, shows progress, and logs results
- extend the simulation pipeline to support UI callbacks and retain the generated output path

## Testing
- python -m compileall baseball_sim
- python -m compileall baseball_sim/ui/gui/gui_startup.py

------
https://chatgpt.com/codex/tasks/task_e_68d0f15621ec832283863554312b2b3a