### PR TITLE
Add browser-based interface for baseball simulator

### DIFF
--- a/baseball_sim/ui/web/__init__.py
+++ b/baseball_sim/ui/web/__init__.py
@@ -1,0 +1,3 @@
+"""Browser-based user interface for the baseball simulator."""
+
+from .app import create_app  # noqa: F401

--- a/baseball_sim/ui/web/app.py
+++ b/baseball_sim/ui/web/app.py
@@ -1,0 +1,90 @@
+"""Flask application exposing the baseball simulator to the browser."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from flask import Flask, jsonify, render_template, request
+
+from .session import GameSessionError, WebGameSession
+
+APP_ROOT = Path(__file__).resolve().parent
+
+
+def create_app() -> Flask:
+    """Create and configure the Flask application."""
+
+    app = Flask(
+        __name__,
+        template_folder=str(APP_ROOT / "templates"),
+        static_folder=str(APP_ROOT / "static"),
+    )
+    session = WebGameSession()
+
+    @app.get("/")
+    def index() -> str:
+        return render_template("index.html")
+
+    @app.get("/api/game/state")
+    def get_state() -> Dict[str, Any]:
+        state = session.build_state()
+        return jsonify(state)
+
+    @app.post("/api/game/start")
+    def start_game() -> Dict[str, Any]:
+        payload = request.get_json(silent=True) or {}
+        reload_teams = bool(payload.get("reload", False))
+        try:
+            state = session.start_new_game(reload_teams=reload_teams)
+        except GameSessionError as exc:
+            return jsonify({"error": str(exc), "state": session.build_state()}), 400
+        return jsonify(state)
+
+    @app.post("/api/game/restart")
+    def restart_game() -> Dict[str, Any]:
+        try:
+            state = session.start_new_game(reload_teams=True)
+        except GameSessionError as exc:
+            return jsonify({"error": str(exc), "state": session.build_state()}), 400
+        return jsonify(state)
+
+    @app.post("/api/game/stop")
+    def stop_game() -> Dict[str, Any]:
+        state = session.stop_game()
+        return jsonify(state)
+
+    @app.post("/api/game/swing")
+    def swing() -> Dict[str, Any]:
+        try:
+            state = session.execute_normal_play()
+        except GameSessionError as exc:
+            return jsonify({"error": str(exc), "state": session.build_state()}), 400
+        return jsonify(state)
+
+    @app.post("/api/game/bunt")
+    def bunt() -> Dict[str, Any]:
+        try:
+            state = session.execute_bunt()
+        except GameSessionError as exc:
+            return jsonify({"error": str(exc), "state": session.build_state()}), 400
+        return jsonify(state)
+
+    @app.post("/api/log/clear")
+    def clear_log() -> Dict[str, Any]:
+        state = session.clear_log()
+        return jsonify(state)
+
+    @app.post("/api/teams/reload")
+    def reload_teams() -> Dict[str, Any]:
+        state = session.reload_teams()
+        return jsonify(state)
+
+    @app.get("/api/health")
+    def health() -> Dict[str, Any]:
+        return jsonify({"status": "ok"})
+
+    return app
+
+
+app = create_app()

--- a/baseball_sim/ui/web/session.py
+++ b/baseball_sim/ui/web/session.py
@@ -1,0 +1,502 @@
+"""Server-side helpers that expose the simulator to a browser client."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+from baseball_sim.config import GameResults, setup_project_environment
+from baseball_sim.data.loader import DataLoader
+from baseball_sim.gameplay.game import GameState
+
+setup_project_environment()
+
+
+class GameSessionError(RuntimeError):
+    """Raised when an action cannot be performed in the current session state."""
+
+
+@dataclass
+class Notification:
+    """Represents a one-off status message for the frontend."""
+
+    level: str
+    message: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return {"level": self.level, "message": self.message}
+
+
+class WebGameSession:
+    """Manage teams, game state and play log for the browser UI."""
+
+    MAX_LOG_ENTRIES = 250
+
+    def __init__(self) -> None:
+        self.home_team = None
+        self.away_team = None
+        self.game_state: Optional[GameState] = None
+        self._log: List[Dict[str, str]] = []
+        self._game_over_announced = False
+        self._action_block_reason: Optional[str] = None
+        self._notification: Optional[Notification] = None
+        self.ensure_teams()
+
+    # ------------------------------------------------------------------
+    # Session lifecycle helpers
+    # ------------------------------------------------------------------
+    def ensure_teams(self, force_reload: bool = False) -> Tuple[Optional[object], Optional[object]]:
+        """Load teams from disk if they are missing or a reload is requested."""
+
+        if force_reload or self.home_team is None or self.away_team is None:
+            self.home_team, self.away_team = DataLoader.create_teams_from_data()
+        return self.home_team, self.away_team
+
+    def start_new_game(self, reload_teams: bool = False) -> Dict[str, object]:
+        """Create a fresh :class:`GameState` and reset session bookkeeping."""
+
+        self.ensure_teams(force_reload=reload_teams)
+        self._ensure_lineups_are_valid()
+
+        if not self.home_team or not self.away_team:
+            raise GameSessionError("Teams could not be loaded from the data files.")
+
+        self.game_state = GameState(self.home_team, self.away_team)
+        self._log.clear()
+        self._game_over_announced = False
+        self._action_block_reason = None
+        self._notification = Notification(
+            level="info",
+            message=f"Game start: {self.away_team.name} at {self.home_team.name}",
+        )
+        self._append_log(self._notification.message, variant="info")
+        self._append_log("=== TOP of the 1 ===", variant="highlight")
+        return self.build_state()
+
+    def stop_game(self) -> Dict[str, object]:
+        """Return to the title screen without discarding loaded teams."""
+
+        self.game_state = None
+        self._game_over_announced = False
+        self._action_block_reason = None
+        self._notification = Notification(level="info", message="Game closed. Return to title screen.")
+        return self.build_state()
+
+    def clear_log(self) -> Dict[str, object]:
+        """Remove all play log entries."""
+
+        self._log.clear()
+        self._notification = Notification(level="info", message="Play log cleared.")
+        return self.build_state()
+
+    def reload_teams(self) -> Dict[str, object]:
+        """Force reloading team data from disk without starting a game."""
+
+        self.ensure_teams(force_reload=True)
+        self.game_state = None
+        self._log.clear()
+        self._game_over_announced = False
+        self._action_block_reason = None
+        self._notification = Notification(level="info", message="Team data reloaded.")
+        return self.build_state()
+
+    # ------------------------------------------------------------------
+    # Gameplay actions
+    # ------------------------------------------------------------------
+    def execute_normal_play(self) -> Dict[str, object]:
+        """Simulate a standard plate appearance."""
+
+        if not self.game_state:
+            raise GameSessionError("Game has not started yet.")
+
+        if self.game_state.game_ended:
+            self._action_block_reason = "The game has already ended."
+            self._append_log(self._action_block_reason, variant="warning")
+            return self.build_state()
+
+        allowed, reason = self.game_state.is_game_action_allowed()
+        if not allowed:
+            self._action_block_reason = reason
+            self._append_log(f"❌ {reason}", variant="danger")
+            return self.build_state()
+
+        self._action_block_reason = None
+
+        batter = self.game_state.batting_team.current_batter
+        pitcher = self.game_state.fielding_team.current_pitcher
+        prev_inning = self.game_state.inning
+        prev_half = self.game_state.is_top_inning
+
+        result = self.game_state.calculate_result(batter, pitcher)
+        message = self.game_state.apply_result(result, batter)
+
+        self._append_log(f"{batter.name} vs {pitcher.name}", variant="header")
+        variant = "success" if result in GameResults.POSITIVE_RESULTS else "danger"
+        self._append_log(message, variant=variant)
+
+        pitcher.decrease_stamina()
+
+        inning_changed = (
+            prev_inning != self.game_state.inning
+            or prev_half != self.game_state.is_top_inning
+        )
+        if not inning_changed:
+            self.game_state.batting_team.next_batter()
+        else:
+            self._append_log(self._half_inning_banner(), variant="highlight")
+
+        if self.game_state.game_ended:
+            self._record_game_over()
+
+        return self.build_state()
+
+    def execute_bunt(self) -> Dict[str, object]:
+        """Attempt a bunt for the current batter."""
+
+        if not self.game_state:
+            raise GameSessionError("Game has not started yet.")
+
+        if self.game_state.game_ended:
+            self._action_block_reason = "The game has already ended."
+            self._append_log(self._action_block_reason, variant="warning")
+            return self.build_state()
+
+        allowed, reason = self.game_state.is_game_action_allowed()
+        if not allowed:
+            self._action_block_reason = reason
+            self._append_log(f"❌ {reason}", variant="danger")
+            return self.build_state()
+
+        if not self.game_state.can_bunt():
+            self._action_block_reason = "Bunt not allowed (need runners on base and fewer than 2 outs)."
+            self._append_log(self._action_block_reason, variant="warning")
+            return self.build_state()
+
+        self._action_block_reason = None
+
+        batter = self.game_state.batting_team.current_batter
+        pitcher = self.game_state.fielding_team.current_pitcher
+        prev_inning = self.game_state.inning
+        prev_half = self.game_state.is_top_inning
+
+        result_message = self.game_state.execute_bunt(batter, pitcher)
+
+        if "Cannot bunt" in result_message or "バントはできません" in result_message:
+            self._action_block_reason = result_message
+            self._append_log(result_message, variant="warning")
+            return self.build_state()
+
+        self._append_log(f"{batter.name} attempts a bunt against {pitcher.name}", variant="header")
+        self._append_log(result_message, variant="success")
+
+        pitcher.decrease_stamina()
+        self.game_state.batting_team.next_batter()
+
+        inning_changed = (
+            prev_inning != self.game_state.inning
+            or prev_half != self.game_state.is_top_inning
+        )
+        if inning_changed:
+            self._append_log(self._half_inning_banner(), variant="highlight")
+
+        if self.game_state.game_ended:
+            self._record_game_over()
+        elif (
+            self.game_state.inning >= 9
+            and not self.game_state.is_top_inning
+            and self.game_state.home_score > self.game_state.away_score
+        ):
+            self._record_game_over()
+
+        return self.build_state()
+
+    # ------------------------------------------------------------------
+    # State serialization
+    # ------------------------------------------------------------------
+    def build_state(self) -> Dict[str, object]:
+        """Return a dictionary representing the entire UI state."""
+
+        title = self._build_title_state()
+        teams = self._build_teams_state()
+        game = self._build_game_state(teams)
+
+        payload = {
+            "title": title,
+            "teams": teams,
+            "game": game,
+            "log": list(self._log),
+        }
+        if self._notification:
+            payload["notification"] = self._notification.to_dict()
+        else:
+            payload["notification"] = None
+        self._notification = None
+        return payload
+
+    # ------------------------------------------------------------------
+    # Helper methods
+    # ------------------------------------------------------------------
+    def _ensure_lineups_are_valid(self) -> None:
+        title_state = self._build_title_state()
+        if not title_state["ready"]:
+            problematic = [
+                f"{info['name']} ({len(info['errors'])} issue(s))"
+                for info in (title_state["home"], title_state["away"])
+                if info and not info["valid"]
+            ]
+            raise GameSessionError(
+                "Cannot start game due to lineup validation issues: " + ", ".join(problematic)
+            )
+
+    def _append_log(self, message: str, variant: str = "info") -> None:
+        if not message:
+            return
+        self._log.append({"text": message, "variant": variant})
+        if len(self._log) > self.MAX_LOG_ENTRIES:
+            del self._log[:-self.MAX_LOG_ENTRIES]
+
+    def _record_game_over(self) -> None:
+        if self._game_over_announced or not self.game_state:
+            return
+
+        home_score = self.game_state.home_score
+        away_score = self.game_state.away_score
+        home_name = self.home_team.name if self.home_team else "Home"
+        away_name = self.away_team.name if self.away_team else "Away"
+
+        self._append_log("Game Over", variant="info")
+        self._append_log(
+            f"Final Score: {away_name} {away_score} - {home_name} {home_score}",
+            variant="info",
+        )
+        if home_score > away_score:
+            self._append_log(f"{home_name} win!", variant="success")
+        elif away_score > home_score:
+            self._append_log(f"{away_name} win!", variant="success")
+        else:
+            self._append_log("Game ends in a tie.", variant="warning")
+
+        self._game_over_announced = True
+        self._notification = Notification(level="info", message="Game finished.")
+
+    def _half_inning_banner(self) -> str:
+        if not self.game_state:
+            return ""
+        half = "TOP" if self.game_state.is_top_inning else "BOTTOM"
+        return f"=== {half} of the {self.game_state.inning} ==="
+
+    def _build_title_state(self) -> Dict[str, object]:
+        home_status = self._team_status(self.home_team)
+        away_status = self._team_status(self.away_team)
+        ready = bool(home_status["valid"] and away_status["valid"])
+
+        if not self.home_team or not self.away_team:
+            hint = "Teams could not be loaded. Check data files."
+        elif ready:
+            hint = "Lineups ready. Press Start Game to begin."
+        else:
+            issues = []
+            if not home_status["valid"]:
+                issues.append(f"{home_status['name']}: {len(home_status['errors'])} issue(s)")
+            if not away_status["valid"]:
+                issues.append(f"{away_status['name']}: {len(away_status['errors'])} issue(s)")
+            hint = "Lineup validation failed: " + ", ".join(issues)
+
+        return {
+            "home": home_status,
+            "away": away_status,
+            "ready": ready,
+            "hint": hint,
+        }
+
+    def _team_status(self, team) -> Dict[str, object]:
+        if not team:
+            return {
+                "name": "-",
+                "valid": False,
+                "message": "Team not loaded",
+                "errors": [],
+            }
+
+        errors = team.validate_lineup()
+        valid = len(errors) == 0
+        message = "✓ Ready" if valid else f"⚠ {len(errors)} issue(s)"
+        return {
+            "name": team.name,
+            "valid": valid,
+            "message": message,
+            "errors": errors,
+        }
+
+    def _build_game_state(self, teams: Dict[str, Optional[Dict[str, object]]]) -> Dict[str, object]:
+        if not self.game_state:
+            return {
+                "active": False,
+                "actions": {"swing": False, "bunt": False},
+                "action_block_reason": self._action_block_reason,
+                "game_over": False,
+                "defensive_errors": [],
+                "score": {"home": 0, "away": 0},
+                "inning_scores": {"home": [], "away": []},
+                "situation": "Waiting for a new game.",
+            }
+
+        batting_team = self.game_state.batting_team
+        offense = None
+        defense = None
+        if batting_team is self.home_team:
+            offense, defense = "home", "away"
+        elif batting_team is self.away_team:
+            offense, defense = "away", "home"
+
+        current_batter = None
+        if batting_team and batting_team.lineup:
+            batter = batting_team.current_batter
+            current_batter = {
+                "name": batter.name,
+                "order": batting_team.current_batter_index + 1,
+                "position": self._display_position(batter),
+            }
+
+        current_pitcher = None
+        if self.game_state.fielding_team and self.game_state.fielding_team.current_pitcher:
+            pitcher = self.game_state.fielding_team.current_pitcher
+            current_pitcher = {
+                "name": pitcher.name,
+                "stamina": round(getattr(pitcher, "current_stamina", 0), 1),
+                "pitcher_type": getattr(pitcher, "pitcher_type", "P"),
+            }
+
+        allowed, reason = self.game_state.is_game_action_allowed()
+        if allowed:
+            self._action_block_reason = None
+
+        inning_scores = self.game_state.inning_scores
+        scoreboard = {
+            "away": list(inning_scores[0]),
+            "home": list(inning_scores[1]),
+        }
+
+        situation = self._format_situation()
+
+        return {
+            "active": True,
+            "inning": self.game_state.inning,
+            "half": "top" if self.game_state.is_top_inning else "bottom",
+            "half_label": "TOP" if self.game_state.is_top_inning else "BOTTOM",
+            "outs": self.game_state.outs,
+            "bases": [
+                {"occupied": runner is not None, "runner": getattr(runner, "name", None)}
+                for runner in self.game_state.bases
+            ],
+            "offense": offense,
+            "defense": defense,
+            "current_batter": current_batter,
+            "current_pitcher": current_pitcher,
+            "score": {"home": self.game_state.home_score, "away": self.game_state.away_score},
+            "inning_scores": scoreboard,
+            "actions": {
+                "swing": allowed and not self.game_state.game_ended,
+                "bunt": allowed and not self.game_state.game_ended and self.game_state.can_bunt(),
+            },
+            "action_block_reason": self._action_block_reason if not allowed else None,
+            "defensive_errors": list(self.game_state.defensive_error_messages),
+            "game_over": self.game_state.game_ended,
+            "situation": situation,
+            "matchup": self._format_matchup(current_batter, current_pitcher),
+        }
+
+    def _build_teams_state(self) -> Dict[str, Optional[Dict[str, object]]]:
+        teams: Dict[str, Optional[Dict[str, object]]] = {"home": None, "away": None}
+        for key, team in (("home", self.home_team), ("away", self.away_team)):
+            if team is None:
+                teams[key] = None
+                continue
+
+            lineup = []
+            is_offense = bool(self.game_state and self.game_state.batting_team is team)
+            current_batter_index = team.current_batter_index if team.lineup else 0
+            for index, player in enumerate(team.lineup):
+                lineup.append(
+                    {
+                        "order": index + 1,
+                        "name": player.name,
+                        "position": self._display_position(player),
+                        "eligible": self._eligible_positions(player),
+                        "is_current_batter": is_offense and index == current_batter_index,
+                    }
+                )
+
+            bench = [
+                {
+                    "name": player.name,
+                    "eligible": self._eligible_positions(player),
+                }
+                for player in team.bench
+            ]
+
+            pitchers = []
+            seen_ids = set()
+            if getattr(team, "current_pitcher", None):
+                current = team.current_pitcher
+                pitchers.append(self._serialize_pitcher(current, is_current=True))
+                seen_ids.add(id(current))
+            for pitcher in team.pitchers:
+                if id(pitcher) in seen_ids:
+                    continue
+                pitchers.append(self._serialize_pitcher(pitcher, is_current=False))
+
+            teams[key] = {
+                "name": team.name,
+                "lineup": lineup,
+                "bench": bench,
+                "pitchers": pitchers,
+            }
+
+        return teams
+
+    def _serialize_pitcher(self, pitcher, is_current: bool) -> Dict[str, object]:
+        return {
+            "name": pitcher.name,
+            "stamina": round(getattr(pitcher, "current_stamina", 0), 1),
+            "pitcher_type": getattr(pitcher, "pitcher_type", "P"),
+            "is_current": is_current,
+        }
+
+    def _eligible_positions(self, player) -> List[str]:
+        if hasattr(player, "get_display_eligible_positions"):
+            return list(player.get_display_eligible_positions())
+        return list(getattr(player, "eligible_positions", []) or [])
+
+    def _display_position(self, player) -> str:
+        position = getattr(player, "current_position", None) or getattr(player, "position", "-")
+        if (
+            position
+            and position.upper() == "P"
+            and hasattr(player, "pitcher_type")
+            and player.pitcher_type in {"SP", "RP"}
+        ):
+            return player.pitcher_type
+        return position or "-"
+
+    def _format_situation(self) -> str:
+        if not self.game_state:
+            return ""
+
+        runners = []
+        if self.game_state.bases[0]:
+            runners.append("1st")
+        if self.game_state.bases[1]:
+            runners.append("2nd")
+        if self.game_state.bases[2]:
+            runners.append("3rd")
+
+        runner_text = "Bases Empty" if not runners else f"Runners on {', '.join(runners)}"
+        half = "Top" if self.game_state.is_top_inning else "Bottom"
+        return f"{half} {self.game_state.inning} — {self.game_state.outs} Outs — {runner_text}"
+
+    @staticmethod
+    def _format_matchup(batter: Optional[Dict[str, object]], pitcher: Optional[Dict[str, object]]) -> Optional[str]:
+        if not batter or not pitcher:
+            return None
+        return f"{batter['name']} vs {pitcher['name']}"

--- a/baseball_sim/ui/web/static/app.js
+++ b/baseball_sim/ui/web/static/app.js
@@ -1,0 +1,343 @@
+const elements = {
+  titleScreen: document.getElementById('title-screen'),
+  gameScreen: document.getElementById('game-screen'),
+  statusMessage: document.getElementById('status-message'),
+  startButton: document.getElementById('start-game'),
+  reloadTeams: document.getElementById('reload-teams'),
+  restartButton: document.getElementById('restart-game'),
+  returnTitle: document.getElementById('return-title'),
+  clearLog: document.getElementById('clear-log'),
+  swingButton: document.getElementById('swing-button'),
+  buntButton: document.getElementById('bunt-button'),
+  actionWarning: document.getElementById('action-warning'),
+  titleHint: document.getElementById('title-hint'),
+  logContainer: document.getElementById('log-entries'),
+  scoreboard: document.getElementById('scoreboard'),
+  situationText: document.getElementById('situation-text'),
+  matchupText: document.getElementById('matchup-text'),
+  halfIndicator: document.getElementById('half-indicator'),
+  outsIndicator: document.getElementById('outs-indicator'),
+  defenseErrors: document.getElementById('defense-errors'),
+  offenseRoster: document.querySelector('#offense-roster tbody'),
+  defenseRoster: document.querySelector('#defense-roster tbody'),
+  homePitchers: document.querySelector('#home-pitchers ul'),
+  awayPitchers: document.querySelector('#away-pitchers ul'),
+  baseState: document.getElementById('base-state'),
+};
+
+const stateCache = {
+  data: null,
+};
+
+async function apiRequest(url, options = {}) {
+  const response = await fetch(url, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options,
+  });
+
+  const payload = await response.json();
+  if (!response.ok) {
+    if (payload.state) {
+      render(payload.state);
+    }
+    if (payload.error) {
+      showStatus(payload.error, 'danger');
+    }
+    throw new Error(payload.error || 'Request failed');
+  }
+  return payload;
+}
+
+function initEventListeners() {
+  elements.startButton.addEventListener('click', () => handleStart(false));
+  elements.reloadTeams.addEventListener('click', handleReloadTeams);
+  elements.restartButton.addEventListener('click', () => handleStart(true));
+  elements.returnTitle.addEventListener('click', handleReturnToTitle);
+  elements.clearLog.addEventListener('click', handleClearLog);
+  elements.swingButton.addEventListener('click', handleSwing);
+  elements.buntButton.addEventListener('click', handleBunt);
+}
+
+async function handleStart(reload) {
+  try {
+    const payload = await apiRequest('/api/game/start', {
+      method: 'POST',
+      body: JSON.stringify({ reload }),
+    });
+    render(payload);
+  } catch (err) {
+    console.warn(err);
+  }
+}
+
+async function handleReloadTeams() {
+  try {
+    const payload = await apiRequest('/api/teams/reload', { method: 'POST' });
+    render(payload);
+  } catch (err) {
+    console.warn(err);
+  }
+}
+
+async function handleReturnToTitle() {
+  try {
+    const payload = await apiRequest('/api/game/stop', { method: 'POST' });
+    render(payload);
+  } catch (err) {
+    console.warn(err);
+  }
+}
+
+async function handleClearLog() {
+  try {
+    const payload = await apiRequest('/api/log/clear', { method: 'POST' });
+    render(payload);
+  } catch (err) {
+    console.warn(err);
+  }
+}
+
+async function handleSwing() {
+  try {
+    const payload = await apiRequest('/api/game/swing', { method: 'POST' });
+    render(payload);
+  } catch (err) {
+    console.warn(err);
+  }
+}
+
+async function handleBunt() {
+  try {
+    const payload = await apiRequest('/api/game/bunt', { method: 'POST' });
+    render(payload);
+  } catch (err) {
+    console.warn(err);
+  }
+}
+
+function render(data) {
+  stateCache.data = data;
+  setStatusMessage(data.notification);
+  renderTitle(data.title);
+  renderGame(data.game, data.teams, data.log);
+}
+
+function setStatusMessage(notification) {
+  if (!notification) {
+    elements.statusMessage.textContent = '';
+    elements.statusMessage.classList.remove('danger', 'success', 'info');
+    return;
+  }
+  elements.statusMessage.textContent = notification.message;
+  elements.statusMessage.classList.remove('danger', 'success', 'info');
+  elements.statusMessage.classList.add(notification.level || 'info');
+}
+
+function renderTitle(titleState) {
+  const homeName = document.querySelector('.team-name[data-team="home"]');
+  const awayName = document.querySelector('.team-name[data-team="away"]');
+  const homeMessage = document.querySelector('.team-message[data-team="home"]');
+  const awayMessage = document.querySelector('.team-message[data-team="away"]');
+  const homeErrors = document.querySelector('.team-errors[data-team="home"]');
+  const awayErrors = document.querySelector('.team-errors[data-team="away"]');
+
+  if (titleState.home) {
+    homeName.textContent = titleState.home.name;
+    homeMessage.textContent = titleState.home.message;
+    homeErrors.innerHTML = '';
+    titleState.home.errors.forEach((err) => {
+      const li = document.createElement('li');
+      li.textContent = err;
+      homeErrors.appendChild(li);
+    });
+  }
+
+  if (titleState.away) {
+    awayName.textContent = titleState.away.name;
+    awayMessage.textContent = titleState.away.message;
+    awayErrors.innerHTML = '';
+    titleState.away.errors.forEach((err) => {
+      const li = document.createElement('li');
+      li.textContent = err;
+      awayErrors.appendChild(li);
+    });
+  }
+
+  elements.titleHint.textContent = titleState.hint || '';
+  elements.startButton.disabled = !titleState.ready;
+}
+
+function renderGame(gameState, teams, log) {
+  if (!gameState.active) {
+    elements.gameScreen.classList.add('hidden');
+    elements.titleScreen.classList.remove('hidden');
+    updateScoreboard(gameState, teams);
+    elements.actionWarning.textContent = '';
+    elements.swingButton.disabled = true;
+    elements.buntButton.disabled = true;
+    updateLog(log || []);
+    elements.defenseErrors.classList.add('hidden');
+    elements.defenseErrors.textContent = '';
+    return;
+  }
+
+  elements.titleScreen.classList.add('hidden');
+  elements.gameScreen.classList.remove('hidden');
+
+  updateScoreboard(gameState, teams);
+  elements.situationText.textContent = gameState.situation || '';
+  elements.halfIndicator.textContent = `${gameState.half_label} ${gameState.inning}`;
+  const outsLabel = gameState.outs === 1 ? 'OUT' : 'OUTS';
+  elements.outsIndicator.textContent = `${gameState.outs} ${outsLabel}`;
+  elements.matchupText.textContent = gameState.matchup || '';
+  updateBases(gameState.bases || []);
+
+  updateRosters(
+    elements.offenseRoster,
+    gameState.offense ? teams[gameState.offense]?.lineup || [] : [],
+  );
+  updateRosters(
+    elements.defenseRoster,
+    gameState.defense ? teams[gameState.defense]?.lineup || [] : [],
+  );
+
+  updatePitchers(elements.homePitchers, teams.home?.pitchers || []);
+  updatePitchers(elements.awayPitchers, teams.away?.pitchers || []);
+
+  updateLog(log || []);
+
+  elements.swingButton.disabled = !gameState.actions?.swing;
+  elements.buntButton.disabled = !gameState.actions?.bunt;
+  elements.actionWarning.textContent = gameState.action_block_reason || '';
+
+  const errors = gameState.defensive_errors || [];
+  if (errors.length) {
+    elements.defenseErrors.classList.remove('hidden');
+    elements.defenseErrors.innerHTML = errors.map((err) => `<p>${err}</p>`).join('');
+  } else {
+    elements.defenseErrors.classList.add('hidden');
+    elements.defenseErrors.textContent = '';
+  }
+}
+
+function updateScoreboard(gameState, teams) {
+  if (!elements.scoreboard) return;
+
+  if (!gameState.active) {
+    elements.scoreboard.innerHTML = '<p>試合はまだ開始されていません。</p>';
+    return;
+  }
+
+  const innings = Math.max(
+    gameState.inning_scores.away.length,
+    gameState.inning_scores.home.length,
+  );
+
+  let html = '<table><thead><tr><th>Team</th>';
+  for (let i = 0; i < innings; i += 1) {
+    html += `<th>${i + 1}</th>`;
+  }
+  html += '<th>R</th></tr></thead><tbody>';
+
+  const awayName = teams.away?.name || 'Away';
+  html += `<tr><td class="team-name">${awayName}</td>`;
+  for (let i = 0; i < innings; i += 1) {
+    const value = gameState.inning_scores.away[i];
+    html += `<td>${value ?? ''}</td>`;
+  }
+  html += `<td>${gameState.score.away}</td></tr>`;
+
+  const homeName = teams.home?.name || 'Home';
+  html += `<tr><td class="team-name">${homeName}</td>`;
+  for (let i = 0; i < innings; i += 1) {
+    const value = gameState.inning_scores.home[i];
+    html += `<td>${value ?? ''}</td>`;
+  }
+  html += `<td>${gameState.score.home}</td></tr>`;
+  html += '</tbody></table>';
+
+  elements.scoreboard.innerHTML = html;
+}
+
+function updateBases(bases) {
+  if (!elements.baseState) return;
+  const baseElements = elements.baseState.querySelectorAll('.base');
+  baseElements.forEach((el) => {
+    const baseIndex = Number(el.dataset.base);
+    const info = bases[baseIndex] || {};
+    const occupied = Boolean(info.occupied);
+    el.classList.toggle('occupied', occupied);
+    const span = el.querySelector('span');
+    if (span) {
+      span.textContent = occupied ? '●' : '';
+    }
+    el.title = info.runner || '';
+  });
+}
+
+function updateRosters(tbody, players) {
+  if (!tbody) return;
+  tbody.innerHTML = '';
+  players.forEach((player) => {
+    const tr = document.createElement('tr');
+    if (player.is_current_batter) {
+      tr.classList.add('active');
+    }
+    tr.innerHTML = `
+      <td>${player.order}</td>
+      <td>${player.position || '-'}</td>
+      <td>${player.name}</td>
+      <td>${(player.eligible || []).join(', ')}</td>
+    `;
+    tbody.appendChild(tr);
+  });
+}
+
+function updatePitchers(listEl, pitchers) {
+  if (!listEl) return;
+  listEl.innerHTML = '';
+  pitchers.forEach((pitcher) => {
+    const li = document.createElement('li');
+    if (pitcher.is_current) {
+      li.classList.add('current');
+    }
+    const stamina = pitcher.stamina != null ? `${pitcher.stamina}` : '-';
+    li.innerHTML = `
+      <span>${pitcher.name} (${pitcher.pitcher_type})</span>
+      <span>${stamina}</span>
+    `;
+    listEl.appendChild(li);
+  });
+}
+
+function updateLog(logEntries) {
+  if (!elements.logContainer) return;
+  elements.logContainer.innerHTML = '';
+  logEntries.forEach((entry) => {
+    const div = document.createElement('div');
+    div.classList.add('log-entry');
+    div.classList.add(entry.variant || 'info');
+    div.textContent = entry.text;
+    elements.logContainer.appendChild(div);
+  });
+  elements.logContainer.scrollTop = elements.logContainer.scrollHeight;
+}
+
+function showStatus(message, level = 'danger') {
+  elements.statusMessage.textContent = message;
+  elements.statusMessage.classList.remove('danger', 'success', 'info');
+  elements.statusMessage.classList.add(level);
+}
+
+async function bootstrap() {
+  initEventListeners();
+  try {
+    const initialState = await apiRequest('/api/game/state');
+    render(initialState);
+  } catch (err) {
+    console.error(err);
+    showStatus('初期状態の取得に失敗しました。ページを再読み込みしてください。', 'danger');
+  }
+}
+
+bootstrap();

--- a/baseball_sim/ui/web/static/styles.css
+++ b/baseball_sim/ui/web/static/styles.css
@@ -1,0 +1,503 @@
+:root {
+  --bg: #111827;
+  --surface: #1f2937;
+  --surface-strong: #0f172a;
+  --accent: #f97316;
+  --accent-muted: #fb923c;
+  --text: #f3f4f6;
+  --text-muted: #d1d5db;
+  --danger: #ef4444;
+  --success: #22c55e;
+  --warning: #facc15;
+  --highlight: #60a5fa;
+  --border: rgba(148, 163, 184, 0.2);
+  --font-body: 'Noto Sans JP', 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  background: radial-gradient(circle at top, #1f2937 0%, #0b1120 70%);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  padding: 24px 32px 16px;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.1), rgba(249, 115, 22, 0.1));
+  border-bottom: 1px solid var(--border);
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 32px;
+  letter-spacing: 0.05em;
+}
+
+.subtitle {
+  margin: 8px 0 0;
+  color: var(--text-muted);
+}
+
+.app-main {
+  flex: 1;
+  padding: 24px 32px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.status-message {
+  min-height: 24px;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.status-message.danger {
+  color: var(--danger);
+}
+
+.status-message.success {
+  color: var(--success);
+}
+
+.status-message.info {
+  color: var(--accent);
+}
+
+.screen.hidden {
+  display: none;
+}
+
+.title-card {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 24px;
+  box-shadow: 0 20px 60px rgba(8, 47, 73, 0.35);
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.title-card h2 {
+  margin-top: 0;
+  letter-spacing: 0.08em;
+}
+
+.team-status-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+  margin: 16px 0 24px;
+}
+
+.team-card {
+  background: rgba(30, 41, 59, 0.8);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px;
+  min-height: 160px;
+}
+
+.team-card h3 {
+  margin: 0 0 8px;
+}
+
+.team-message {
+  font-weight: 600;
+}
+
+.team-errors {
+  margin: 12px 0 0;
+  padding-left: 20px;
+  color: var(--warning);
+  font-size: 14px;
+}
+
+.title-hint {
+  margin: 0 0 16px;
+  color: var(--text-muted);
+}
+
+.title-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 12px 20px;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text);
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+button.primary {
+  background: linear-gradient(135deg, var(--accent) 0%, #f97316 60%, #fb923c 100%);
+  color: #111827;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: rgba(148, 163, 184, 0.22);
+}
+
+button.primary:hover:not(:disabled) {
+  background: linear-gradient(135deg, #fb923c 0%, #f59e0b 100%);
+}
+
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 20px;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  margin-bottom: 16px;
+}
+
+.toolbar-left,
+.toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.action-warning {
+  color: var(--warning);
+  font-weight: 600;
+}
+
+.game-layout {
+  display: grid;
+  grid-template-columns: minmax(480px, 3fr) minmax(280px, 2fr);
+  gap: 24px;
+}
+
+.field-column {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.control-column {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.scoreboard {
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 16px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  overflow-x: auto;
+}
+
+.scoreboard table {
+  width: 100%;
+  border-collapse: collapse;
+  color: var(--text);
+}
+
+.scoreboard th,
+.scoreboard td {
+  padding: 8px 12px;
+  text-align: center;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.scoreboard th {
+  font-weight: 700;
+  color: var(--accent-muted);
+}
+
+.scoreboard td.team-name {
+  text-align: left;
+  font-weight: 600;
+}
+
+.situation-panel {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px 20px;
+}
+
+.inning-chip,
+.outs-chip {
+  min-width: 80px;
+  text-align: center;
+  padding: 10px 12px;
+  border-radius: 12px;
+  font-weight: 700;
+  background: rgba(96, 165, 250, 0.12);
+}
+
+.situation-text {
+  flex: 1;
+}
+
+.situation-text p {
+  margin: 4px 0;
+}
+
+.matchup {
+  color: var(--text-muted);
+}
+
+.bases {
+  position: relative;
+  height: 200px;
+  background: radial-gradient(circle at center, rgba(34, 197, 94, 0.15), rgba(34, 197, 94, 0));
+  border-radius: 16px;
+  border: 1px solid var(--border);
+}
+
+.base {
+  position: absolute;
+  width: 60px;
+  height: 60px;
+  transform: rotate(45deg);
+  border: 2px solid rgba(248, 250, 252, 0.4);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text);
+}
+
+.base span {
+  transform: rotate(-45deg);
+  font-weight: 700;
+}
+
+.base.occupied {
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.9), rgba(59, 130, 246, 0.7));
+}
+
+.base1 {
+  bottom: 24px;
+  right: 48px;
+}
+
+.base2 {
+  top: 24px;
+  right: 48px;
+}
+
+.base3 {
+  top: 24px;
+  left: 48px;
+}
+
+.home-plate {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+  width: 48px;
+  height: 48px;
+  border: 2px solid rgba(248, 250, 252, 0.5);
+  border-radius: 8px;
+}
+
+.roster-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.roster {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 12px 16px;
+}
+
+.roster table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.roster th,
+.roster td {
+  padding: 6px 8px;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.roster tbody tr.active {
+  background: rgba(96, 165, 250, 0.12);
+}
+
+.pitchers-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.pitcher-list {
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px;
+}
+
+.pitcher-list ul {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.pitcher-list li {
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(30, 41, 59, 0.8);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pitcher-list li.current {
+  border: 1px solid rgba(96, 165, 250, 0.7);
+  background: rgba(59, 130, 246, 0.15);
+}
+
+.controls-card {
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.defense-alert {
+  min-height: 32px;
+  border-radius: 12px;
+  padding: 12px 16px;
+  background: rgba(250, 204, 21, 0.12);
+  border: 1px solid rgba(250, 204, 21, 0.35);
+  color: var(--warning);
+  font-weight: 600;
+}
+
+.defense-alert.hidden {
+  display: none;
+}
+
+.log-panel {
+  flex: 1;
+  background: rgba(15, 23, 42, 0.8);
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+}
+
+.log-entries {
+  flex: 1;
+  margin-top: 12px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.log-entry {
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(30, 41, 59, 0.8);
+  border-left: 4px solid transparent;
+  line-height: 1.5;
+}
+
+.log-entry.info {
+  border-color: rgba(148, 163, 184, 0.6);
+}
+
+.log-entry.success {
+  border-color: var(--success);
+  color: var(--success);
+}
+
+.log-entry.danger {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.log-entry.warning {
+  border-color: var(--warning);
+  color: var(--warning);
+}
+
+.log-entry.highlight {
+  border-color: var(--highlight);
+  color: var(--highlight);
+}
+
+.log-entry.header {
+  border-color: var(--accent);
+  color: var(--accent-muted);
+  font-weight: 700;
+}
+
+.app-footer {
+  padding: 16px 32px;
+  text-align: center;
+  color: var(--text-muted);
+  border-top: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.6);
+}
+
+@media (max-width: 960px) {
+  .game-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .toolbar-left,
+  .toolbar-right {
+    justify-content: space-between;
+  }
+
+  button {
+    width: 100%;
+  }
+}

--- a/baseball_sim/ui/web/templates/index.html
+++ b/baseball_sim/ui/web/templates/index.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Baseball Simulation</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="app-header">
+        <h1>Baseball Simulation</h1>
+        <p class="subtitle">ブラウザで遊べる野球シミュレーター</p>
+      </header>
+
+      <main class="app-main">
+        <div id="status-message" class="status-message" role="status"></div>
+
+        <section id="title-screen" class="screen">
+          <div class="title-card">
+            <h2>チーム状況</h2>
+            <div class="team-status-grid">
+              <div class="team-card" id="away-team-card">
+                <h3 class="team-name" data-team="away">Away</h3>
+                <p class="team-message" data-team="away"></p>
+                <ul class="team-errors" data-team="away"></ul>
+              </div>
+              <div class="team-card" id="home-team-card">
+                <h3 class="team-name" data-team="home">Home</h3>
+                <p class="team-message" data-team="home"></p>
+                <ul class="team-errors" data-team="home"></ul>
+              </div>
+            </div>
+            <p class="title-hint" id="title-hint"></p>
+            <div class="title-actions">
+              <button id="start-game" class="primary">ゲーム開始</button>
+              <button id="reload-teams">データ再読込</button>
+            </div>
+          </div>
+        </section>
+
+        <section id="game-screen" class="screen hidden">
+          <div class="toolbar">
+            <div class="toolbar-left">
+              <button id="restart-game">新しい試合</button>
+              <button id="return-title">タイトルへ</button>
+              <button id="clear-log">ログをクリア</button>
+            </div>
+            <div class="toolbar-right">
+              <span id="action-warning" class="action-warning"></span>
+            </div>
+          </div>
+
+          <div class="game-layout">
+            <div class="field-column">
+              <div class="scoreboard" id="scoreboard"></div>
+
+              <div class="situation-panel">
+                <div class="inning-chip" id="half-indicator"></div>
+                <div class="situation-text">
+                  <p id="situation-text">状況</p>
+                  <p id="matchup-text" class="matchup"></p>
+                </div>
+                <div class="outs-chip" id="outs-indicator"></div>
+              </div>
+
+              <div class="bases" id="base-state">
+                <div class="base base3" data-base="2"><span></span></div>
+                <div class="base base2" data-base="1"><span></span></div>
+                <div class="base base1" data-base="0"><span></span></div>
+                <div class="home-plate"></div>
+              </div>
+
+              <div class="roster-panel">
+                <div class="roster" id="offense-roster">
+                  <h3>攻撃</h3>
+                  <table>
+                    <thead>
+                      <tr><th>#</th><th>Pos</th><th>選手</th><th>Eligible</th></tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+                <div class="roster" id="defense-roster">
+                  <h3>守備</h3>
+                  <table>
+                    <thead>
+                      <tr><th>#</th><th>Pos</th><th>選手</th><th>Eligible</th></tr>
+                    </thead>
+                    <tbody></tbody>
+                  </table>
+                </div>
+              </div>
+
+              <div class="pitchers-panel">
+                <div class="pitcher-list" id="home-pitchers">
+                  <h3>Home Pitchers</h3>
+                  <ul></ul>
+                </div>
+                <div class="pitcher-list" id="away-pitchers">
+                  <h3>Away Pitchers</h3>
+                  <ul></ul>
+                </div>
+              </div>
+            </div>
+
+            <div class="control-column">
+              <div class="controls-card">
+                <h3>打撃操作</h3>
+                <button id="swing-button" class="primary">通常打撃</button>
+                <button id="bunt-button">バント</button>
+              </div>
+
+              <div class="defense-alert" id="defense-errors"></div>
+
+              <div class="log-panel">
+                <h3>試合ログ</h3>
+                <div class="log-entries" id="log-entries"></div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="app-footer">
+        <small>&copy; 2024 Baseball Simulation</small>
+      </footer>
+    </div>
+
+    <script src="{{ url_for('static', filename='app.js') }}" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a Flask application that exposes REST endpoints for game control and state retrieval for browser clients
- implement a server-side WebGameSession helper to translate simulator events into JSON-friendly payloads and maintain play logs
- build a single-page HTML/JS/CSS front end that mirrors the desktop layout with scoreboards, rosters, bases, controls, and live log updates

## Testing
- python -m compileall baseball_sim/ui/web

------
https://chatgpt.com/codex/tasks/task_e_68d10556ca04832292bbcf84a2e66d32