### PR TITLE
Improve web UI strategy controls and scoreboard

### DIFF
--- a/baseball_sim/ui/web/app.py
+++ b/baseball_sim/ui/web/app.py
@@ -70,6 +70,56 @@ def create_app() -> Flask:
             return jsonify({"error": str(exc), "state": session.build_state()}), 400
         return jsonify(state)
 
+    @app.post("/api/strategy/pinch_hit")
+    def pinch_hit() -> Dict[str, Any]:
+        payload = request.get_json(silent=True) or {}
+        try:
+            lineup_index = int(payload.get("lineup_index", -1))
+        except (TypeError, ValueError):
+            lineup_index = -1
+        try:
+            bench_index = int(payload.get("bench_index", -1))
+        except (TypeError, ValueError):
+            bench_index = -1
+        try:
+            state = session.execute_pinch_hit(lineup_index=lineup_index, bench_index=bench_index)
+        except GameSessionError as exc:
+            return jsonify({"error": str(exc), "state": session.build_state()}), 400
+        return jsonify(state)
+
+    @app.post("/api/strategy/defense_substitution")
+    def defensive_substitution() -> Dict[str, Any]:
+        payload = request.get_json(silent=True) or {}
+        try:
+            lineup_index = int(payload.get("lineup_index", -1))
+        except (TypeError, ValueError):
+            lineup_index = -1
+        try:
+            bench_index = int(payload.get("bench_index", -1))
+        except (TypeError, ValueError):
+            bench_index = -1
+        try:
+            state = session.execute_defensive_substitution(
+                lineup_index=lineup_index,
+                bench_index=bench_index,
+            )
+        except GameSessionError as exc:
+            return jsonify({"error": str(exc), "state": session.build_state()}), 400
+        return jsonify(state)
+
+    @app.post("/api/strategy/change_pitcher")
+    def change_pitcher() -> Dict[str, Any]:
+        payload = request.get_json(silent=True) or {}
+        try:
+            pitcher_index = int(payload.get("pitcher_index", -1))
+        except (TypeError, ValueError):
+            pitcher_index = -1
+        try:
+            state = session.execute_pitcher_change(pitcher_index=pitcher_index)
+        except GameSessionError as exc:
+            return jsonify({"error": str(exc), "state": session.build_state()}), 400
+        return jsonify(state)
+
     @app.post("/api/log/clear")
     def clear_log() -> Dict[str, Any]:
         state = session.clear_log()

--- a/baseball_sim/ui/web/static/styles.css
+++ b/baseball_sim/ui/web/static/styles.css
@@ -403,6 +403,32 @@ button:disabled {
   gap: 12px;
 }
 
+.controls-card label {
+  font-size: 13px;
+  color: var(--text-muted);
+  text-transform: none;
+}
+
+.controls-card select {
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  padding: 10px 12px;
+  background: rgba(30, 41, 59, 0.9);
+  color: var(--text);
+  font-size: 14px;
+  appearance: none;
+}
+
+.controls-card select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.strategy-card button {
+  margin-top: 4px;
+}
+
 .defense-alert {
   min-height: 32px;
   border-radius: 12px;
@@ -472,6 +498,50 @@ button:disabled {
   border-color: var(--accent);
   color: var(--accent-muted);
   font-weight: 700;
+}
+
+.bench-section {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.bench-section h4 {
+  margin: 0 0 8px;
+  font-size: 13px;
+  color: var(--text-muted);
+  letter-spacing: 0.05em;
+}
+
+.bench-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.bench-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(30, 41, 59, 0.8);
+  font-size: 13px;
+  color: var(--text);
+}
+
+.bench-list li span:last-child {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.bench-list li.empty {
+  justify-content: center;
+  color: var(--text-muted);
+  font-style: italic;
 }
 
 .app-footer {

--- a/baseball_sim/ui/web/templates/index.html
+++ b/baseball_sim/ui/web/templates/index.html
@@ -80,6 +80,10 @@
                     </thead>
                     <tbody></tbody>
                   </table>
+                  <div class="bench-section">
+                    <h4>ベンチ</h4>
+                    <ul id="offense-bench" class="bench-list"></ul>
+                  </div>
                 </div>
                 <div class="roster" id="defense-roster">
                   <h3>守備</h3>
@@ -89,6 +93,10 @@
                     </thead>
                     <tbody></tbody>
                   </table>
+                  <div class="bench-section">
+                    <h4>ベンチ</h4>
+                    <ul id="defense-bench" class="bench-list"></ul>
+                  </div>
                 </div>
               </div>
 
@@ -109,6 +117,27 @@
                 <h3>打撃操作</h3>
                 <button id="swing-button" class="primary">通常打撃</button>
                 <button id="bunt-button">バント</button>
+              </div>
+
+              <div class="controls-card strategy-card" id="offense-strategy">
+                <h3>采配（攻撃）</h3>
+                <label for="pinch-target">代打対象</label>
+                <select id="pinch-target"></select>
+                <label for="pinch-player">ベンチ選手</label>
+                <select id="pinch-player"></select>
+                <button id="pinch-hit-button">代打を送る</button>
+              </div>
+
+              <div class="controls-card strategy-card" id="defense-strategy">
+                <h3>采配（守備）</h3>
+                <label for="defense-target">交代する守備位置</label>
+                <select id="defense-target"></select>
+                <label for="defense-player">ベンチ選手</label>
+                <select id="defense-player"></select>
+                <button id="defense-sub-button">守備交代</button>
+                <label for="pitcher-select">投手交代</label>
+                <select id="pitcher-select"></select>
+                <button id="change-pitcher-button">新しい投手を投入</button>
               </div>
 
               <div class="defense-alert" id="defense-errors"></div>


### PR DESCRIPTION
## Summary
- add web session helpers and API routes for pinch hitting, defensive substitutions, and pitcher changes while exposing hit/error totals
- render bench lists, strategy controls, and an expanded scoreboard in the browser client
- style the new strategy panels and bench displays for readability

## Testing
- pytest *(fails: missing `joblib` and `torch` dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d10e8753788322a024a7a510e337cd