### PR TITLE
Improve web UI strategy menus and base layout

### DIFF
--- a/baseball_sim/ui/web/static/styles.css
+++ b/baseball_sim/ui/web/static/styles.css
@@ -312,8 +312,8 @@ button:disabled {
 }
 
 .base-first {
-  top: 60%;
-  left: 82%;
+  top: 50%;
+  left: 80%;
 }
 
 .base-second {
@@ -322,13 +322,13 @@ button:disabled {
 }
 
 .base-third {
-  top: 60%;
-  left: 18%;
+  top: 50%;
+  left: 20%;
 }
 
 .home-plate {
   position: absolute;
-  top: 82%;
+  top: 80%;
   left: 50%;
   transform: translate(-50%, -50%) rotate(45deg);
   width: 52px;
@@ -423,6 +423,33 @@ button:disabled {
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.strategy-menu {
+  margin-top: 12px;
+  padding: 12px 16px;
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.strategy-menu-title {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.strategy-menu-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.strategy-menu-actions button {
+  flex: 1 1 140px;
 }
 
 .controls-card label {
@@ -660,6 +687,15 @@ button:disabled {
   font-size: 14px;
 }
 
+.current-batter {
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: rgba(30, 41, 59, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
 .form-grid {
   display: grid;
   gap: 12px;
@@ -847,6 +883,11 @@ button:disabled {
 
 .pitcher-change select {
   width: 100%;
+}
+
+.pitcher-change label {
+  font-size: 14px;
+  color: var(--text-muted);
 }
 
 .stats-modal-body {

--- a/baseball_sim/ui/web/templates/index.html
+++ b/baseball_sim/ui/web/templates/index.html
@@ -122,6 +122,17 @@
                   <button id="open-defense-strategy">守備側采配</button>
                   <button id="open-stats">成績</button>
                 </div>
+                <div
+                  class="strategy-menu hidden"
+                  id="defense-strategy-menu"
+                  aria-hidden="true"
+                >
+                  <p class="strategy-menu-title">守備側の采配を選択</p>
+                  <div class="strategy-menu-actions">
+                    <button type="button" id="open-defense-sub">守備交代</button>
+                    <button type="button" id="open-pitcher-change-menu">投手交代</button>
+                  </div>
+                </div>
               </div>
 
               <div class="defense-alert hidden" id="defense-errors"></div>
@@ -147,11 +158,10 @@
           <button type="button" class="modal-close" data-close="offense-modal" aria-label="閉じる">&times;</button>
         </div>
         <div class="modal-body">
-          <p class="modal-description">代打を送りたい打順とベンチ選手を選択してください。</p>
+          <p class="modal-description">現在の打者に代打を送ります。ベンチから選手を選択してください。</p>
+          <div class="current-batter" id="pinch-current-batter">現在の打者: -</div>
           <div class="form-grid">
-            <label for="pinch-target">代打を出す打順</label>
-            <select id="pinch-target"></select>
-            <label for="pinch-player">ベンチ選手</label>
+            <label for="pinch-player">代打に出すベンチ選手</label>
             <select id="pinch-player"></select>
           </div>
         </div>
@@ -183,11 +193,25 @@
           <div class="defense-actions">
             <button id="defense-sub-button" class="primary">守備交代を適用</button>
           </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="modal hidden" id="pitcher-modal" aria-hidden="true">
+      <div class="modal-card strategy-modal" role="dialog" aria-modal="true" aria-labelledby="pitcher-modal-title">
+        <div class="modal-header">
+          <h3 id="pitcher-modal-title">投手交代</h3>
+          <button type="button" class="modal-close" data-close="pitcher-modal" aria-label="閉じる">&times;</button>
+        </div>
+        <div class="modal-body">
+          <p class="modal-description">交代する投手を選択してください。</p>
           <div class="pitcher-change">
-            <h4>投手交代</h4>
+            <label for="pitcher-select">投手</label>
             <select id="pitcher-select"></select>
-            <button id="change-pitcher-button">新しい投手を投入</button>
           </div>
+        </div>
+        <div class="modal-footer">
+          <button id="change-pitcher-button" class="primary">新しい投手を投入</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- align the on-field base markers so that home, first, second and third form a proper diamond
- add a defense strategy popover with separate buttons for defensive swaps and pitcher changes, including a dedicated pitcher change modal
- simplify pinch-hit flows so the current batter is targeted automatically with updated UI copy and styling

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d11b1e6c048322b7abc25098fa4675