### PR TITLE
Align web defensive substitution logic with GUI

### DIFF
--- a/baseball_sim/ui/web/session.py
+++ b/baseball_sim/ui/web/session.py
@@ -501,7 +501,9 @@ class WebGameSession:
                         "order": index + 1,
                         "name": player.name,
                         "position": self._display_position(player),
+                        "position_key": self._defensive_position_key(player),
                         "eligible": self._eligible_positions(player),
+                        "eligible_all": self._eligible_positions_raw(player),
                         "is_current_batter": is_offense and index == current_batter_index,
                     }
                 )
@@ -518,6 +520,7 @@ class WebGameSession:
                         "index": bench_index,
                         "name": player.name,
                         "eligible": self._eligible_positions(player),
+                        "eligible_all": self._eligible_positions_raw(player),
                     }
                 )
 
@@ -697,6 +700,19 @@ class WebGameSession:
         if hasattr(player, "get_display_eligible_positions"):
             return list(player.get_display_eligible_positions())
         return list(getattr(player, "eligible_positions", []) or [])
+
+    def _eligible_positions_raw(self, player) -> List[str]:
+        positions = getattr(player, "eligible_positions", []) or []
+        return [str(pos).upper() for pos in positions]
+
+    def _defensive_position_key(self, player) -> Optional[str]:
+        position = getattr(player, "current_position", None) or getattr(player, "position", None)
+        if not position:
+            return None
+        position_key = str(position).upper()
+        if position_key in {"SP", "RP"}:
+            return "P"
+        return position_key
 
     def _display_position(self, player) -> str:
         position = getattr(player, "current_position", None) or getattr(player, "position", "-")

--- a/baseball_sim/ui/web/static/styles.css
+++ b/baseball_sim/ui/web/static/styles.css
@@ -853,6 +853,12 @@ button:disabled {
   transform: none;
 }
 
+.defense-bench button.bench-card.ineligible,
+.defense-extras button.bench-card.ineligible {
+  border-color: rgba(239, 68, 68, 0.6);
+  background: rgba(239, 68, 68, 0.12);
+}
+
 .bench-card .eligible-label {
   font-size: 12px;
   color: var(--text-muted);
@@ -861,6 +867,11 @@ button:disabled {
 .bench-card .eligible-positions {
   font-size: 12px;
   color: var(--text-muted);
+}
+
+.bench-card .ineligible-hint {
+  font-size: 12px;
+  color: var(--danger);
 }
 
 .selection-info {


### PR DESCRIPTION
## Summary
- expose defensive position keys and full eligibility data to the web client
- mirror the GUI substitution flow in the web UI by disabling ineligible bench options and validating selections
- add styling and client-side guards so defensive swaps only proceed with valid combinations

## Testing
- python -m compileall baseball_sim/ui/web

------
https://chatgpt.com/codex/tasks/task_e_68d123d9f4d88322a4cb37010dae5bef