### PR TITLE
feat(web): align web UI outs and position colors with GUI

### DIFF
--- a/baseball_sim/ui/web/session.py
+++ b/baseball_sim/ui/web/session.py
@@ -426,6 +426,7 @@ class WebGameSession:
                 "name": batter.name,
                 "order": batting_team.current_batter_index + 1,
                 "position": self._display_position(batter),
+                "pitcher_type": getattr(batter, "pitcher_type", None),
             }
 
         current_pitcher = None
@@ -504,6 +505,7 @@ class WebGameSession:
                         "position_key": self._defensive_position_key(player),
                         "eligible": self._eligible_positions(player),
                         "eligible_all": self._eligible_positions_raw(player),
+                        "pitcher_type": getattr(player, "pitcher_type", None),
                         "is_current_batter": is_offense and index == current_batter_index,
                     }
                 )
@@ -521,6 +523,7 @@ class WebGameSession:
                         "name": player.name,
                         "eligible": self._eligible_positions(player),
                         "eligible_all": self._eligible_positions_raw(player),
+                        "pitcher_type": getattr(player, "pitcher_type", None),
                     }
                 )
 

--- a/baseball_sim/ui/web/static/styles.css
+++ b/baseball_sim/ui/web/static/styles.css
@@ -30,6 +30,18 @@ body {
   display: none !important;
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .app-shell {
   min-height: 100vh;
   display: flex;
@@ -261,6 +273,40 @@ button:disabled {
   border-radius: 12px;
   font-weight: 700;
   background: rgba(96, 165, 250, 0.12);
+}
+
+.outs-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+.outs-dots {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.out-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(239, 68, 68, 0.6);
+  background: rgba(248, 250, 252, 0.25);
+  box-shadow: inset 0 2px 4px rgba(15, 23, 42, 0.35);
+}
+
+.out-dot.active {
+  background: var(--danger);
+  border-color: rgba(239, 68, 68, 0.95);
+  box-shadow: 0 0 10px rgba(239, 68, 68, 0.35);
+}
+
+.outs-label {
+  letter-spacing: 0.12em;
+  font-size: 13px;
+  color: var(--danger);
 }
 
 .situation-text {
@@ -992,6 +1038,62 @@ button:disabled {
   text-align: center;
   font-style: italic;
   color: var(--text-muted);
+}
+
+.position-token {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: var(--text);
+}
+
+.position-token.position-token-empty {
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.position-separator {
+  margin: 0 4px;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.position-list {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 0;
+}
+
+.position-list .position-token {
+  margin: 0;
+}
+
+.bench-list li .position-list {
+  justify-content: flex-end;
+}
+
+.position-token.pos-color-sp {
+  color: var(--danger);
+}
+
+.position-token.pos-color-rp {
+  color: #c084fc;
+}
+
+.position-token.pos-color-c {
+  color: var(--highlight);
+}
+
+.position-token.pos-color-infield {
+  color: var(--accent);
+}
+
+.position-token.pos-color-outfield {
+  color: var(--success);
 }
 
 @media (max-width: 960px) {


### PR DESCRIPTION
## Summary
- include pitcher type metadata in the web game state so the frontend can colorize position tokens consistently
- render the outs indicator with GUI-style red circles and add helpers to output colored position badges across the web UI
- style roster, bench, and defense panels with the new colored position tokens to match the desktop presentation

## Testing
- pytest *(fails: missing joblib/torch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d12d7dde3883229b384d3c4bc67bca