### PR TITLE
Enhance web field rendering with outfield

### DIFF
--- a/baseball_sim/ui/web/static/styles.css
+++ b/baseball_sim/ui/web/static/styles.css
@@ -384,38 +384,151 @@ button:disabled {
 
 .bases {
   position: relative;
-  width: 240px;
-  height: 240px;
-  margin: 12px auto 0;
-  background: radial-gradient(circle at center, rgba(34, 197, 94, 0.18), rgba(34, 197, 94, 0));
-  border-radius: 18px;
+  width: 280px;
+  height: 280px;
+  margin: 16px auto 0;
+  background: radial-gradient(circle at 50% 92%, rgba(15, 23, 42, 0.35), rgba(2, 6, 23, 0.92));
+  border-radius: 28px;
   border: 1px solid var(--border);
+  box-shadow: 0 28px 50px rgba(8, 47, 73, 0.55);
+  overflow: hidden;
+}
+
+.field-layer {
+  position: absolute;
+  pointer-events: none;
+}
+
+.field-outfield {
+  width: 360px;
+  height: 360px;
+  top: -230px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 50% 78%,
+    rgba(16, 185, 129, 0.92) 0%,
+    rgba(16, 185, 129, 0.92) 58%,
+    rgba(21, 128, 61, 0.88) 66%,
+    rgba(120, 53, 15, 0.85) 74%,
+    rgba(120, 53, 15, 0)
+  );
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.45);
+  z-index: 0;
+}
+
+.field-infield-grass {
+  width: 200px;
+  height: 200px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(45deg);
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.95), rgba(15, 118, 110, 0.85));
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.35);
+  z-index: 1;
+}
+
+.field-infield-baseline {
+  width: 120px;
+  height: 120px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(45deg);
+  border-radius: 16px;
+  border: 4px solid rgba(248, 250, 252, 0.95);
+  z-index: 2;
+  box-shadow: 0 0 14px rgba(248, 250, 252, 0.35);
+}
+
+.field-infield-dirt {
+  width: 96px;
+  height: 96px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(45deg);
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(214, 162, 93, 0.95), rgba(168, 108, 43, 0.88));
+  border: 2px solid rgba(214, 162, 93, 0.8);
+  box-shadow: inset 0 0 18px rgba(107, 64, 31, 0.45);
+  z-index: 3;
+}
+
+.foul-line {
+  width: 4px;
+  height: 220px;
+  bottom: 20%;
+  left: 50%;
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.95), rgba(248, 250, 252, 0.2));
+  transform-origin: bottom center;
+  filter: drop-shadow(0 0 6px rgba(15, 23, 42, 0.45));
+  z-index: 4;
+  opacity: 0.92;
+}
+
+.foul-line-left {
+  transform: translateX(-50%) rotate(-45deg);
+}
+
+.foul-line-right {
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.pitcher-mound {
+  width: 48px;
+  height: 48px;
+  top: 42%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 40%, rgba(224, 180, 111, 0.95), rgba(163, 98, 40, 0.85));
+  border: 2px solid rgba(248, 250, 252, 0.35);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.45);
+  z-index: 5;
+}
+
+.pitcher-mound::after {
+  content: '';
+  position: absolute;
+  inset: 18%;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(214, 162, 93, 0.95), rgba(168, 108, 43, 0.85));
+  box-shadow: inset 0 0 8px rgba(107, 64, 31, 0.45);
 }
 
 .base {
   position: absolute;
-  width: 56px;
-  height: 56px;
+  width: 52px;
+  height: 52px;
   transform: translate(-50%, -50%) rotate(45deg);
-  border: 2px solid rgba(248, 250, 252, 0.45);
+  border: 2px solid rgba(15, 23, 42, 0.15);
   border-radius: 14px;
+  background: rgba(248, 250, 252, 0.95);
+  box-shadow: 0 12px 22px rgba(15, 23, 42, 0.45);
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--text);
-  background: rgba(15, 23, 42, 0.6);
-  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.35);
+  transition: background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+  z-index: 6;
 }
 
 .base span {
   transform: rotate(-45deg);
-  font-weight: 700;
-  font-size: 20px;
+  font-weight: 800;
+  font-size: 22px;
+  color: rgba(248, 250, 252, 0.96);
+  text-shadow: 0 0 6px rgba(15, 23, 42, 0.6);
 }
 
 .base.occupied {
-  background: linear-gradient(135deg, rgba(96, 165, 250, 0.9), rgba(59, 130, 246, 0.75));
-  border-color: rgba(191, 219, 254, 0.9);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.92), rgba(37, 99, 235, 0.9));
+  border-color: rgba(191, 219, 254, 0.95);
+  box-shadow: 0 0 18px rgba(59, 130, 246, 0.55);
+}
+
+.base.occupied span {
+  color: rgba(248, 250, 252, 0.98);
 }
 
 .base-first {
@@ -438,12 +551,21 @@ button:disabled {
   top: 80%;
   left: 50%;
   transform: translate(-50%, -50%) rotate(45deg);
-  width: 52px;
-  height: 52px;
-  border: 2px solid rgba(248, 250, 252, 0.55);
-  border-radius: 12px;
-  background: rgba(15, 23, 42, 0.7);
-  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.4);
+  width: 54px;
+  height: 54px;
+  border: 2px solid rgba(148, 163, 184, 0.45);
+  border-radius: 14px;
+  background: rgba(248, 250, 252, 0.95);
+  box-shadow: 0 14px 26px rgba(15, 23, 42, 0.45);
+  z-index: 6;
+}
+
+.home-plate::after {
+  content: '';
+  position: absolute;
+  inset: 10px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.2), rgba(148, 163, 184, 0));
 }
 
 .roster-panel {

--- a/baseball_sim/ui/web/templates/index.html
+++ b/baseball_sim/ui/web/templates/index.html
@@ -69,6 +69,13 @@
               </div>
 
               <div class="bases" id="base-state">
+                <div class="field-layer field-outfield" aria-hidden="true"></div>
+                <div class="field-layer field-infield-grass" aria-hidden="true"></div>
+                <div class="field-layer field-infield-baseline" aria-hidden="true"></div>
+                <div class="field-layer field-infield-dirt" aria-hidden="true"></div>
+                <div class="field-layer foul-line foul-line-left" aria-hidden="true"></div>
+                <div class="field-layer foul-line foul-line-right" aria-hidden="true"></div>
+                <div class="field-layer pitcher-mound" aria-hidden="true"></div>
                 <div class="home-plate" aria-hidden="true"></div>
                 <div class="base base-third" data-base="2"><span></span></div>
                 <div class="base base-second" data-base="1"><span></span></div>


### PR DESCRIPTION
## Summary
- add layered field markup so the web diamond can render an outfield arc, foul lines, and the mound similar to the GUI
- restyle the web field CSS to draw the new layers and refresh the base and home plate presentation

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'joblib' / 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68d16e94ca748322bc39f418fbabd681