### PR TITLE
Add offense strategy menu with pinch hitting option

### DIFF
--- a/baseball_sim/ui/web/templates/index.html
+++ b/baseball_sim/ui/web/templates/index.html
@@ -135,6 +135,16 @@
                 </div>
                 <div
                   class="strategy-menu hidden"
+                  id="offense-strategy-menu"
+                  aria-hidden="true"
+                >
+                  <p class="strategy-menu-title">攻撃側の采配を選択</p>
+                  <div class="strategy-menu-actions">
+                    <button type="button" id="open-offense-pinch-menu">代打戦略</button>
+                  </div>
+                </div>
+                <div
+                  class="strategy-menu hidden"
                   id="defense-strategy-menu"
                   aria-hidden="true"
                 >


### PR DESCRIPTION
## Summary
- add an offense strategy popover with a pinch-hitting entry to mirror the defense flow
- update the web UI logic to toggle the new menu, close it appropriately, and reuse existing pinch-hit modal behaviour
- keep strategy controls in sync with game state by disabling or hiding the offense menu when pinch hitting is unavailable

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'joblib', ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68d17b33ba6483229eb877bc273eafc0