### PR TITLE
Make web UI tolerant of missing optional dependencies

### DIFF
--- a/baseball_sim/__init__.py
+++ b/baseball_sim/__init__.py
@@ -1,5 +1,26 @@
 """Baseball simulation package."""
 
-from baseball_sim.app.main import main
+from __future__ import annotations
+
+from typing import Any
 
 __all__ = ["main"]
+
+
+def main(*args: Any, **kwargs: Any) -> Any:
+    """Entry point wrapper that defers heavy imports until execution.
+
+    Importing :mod:`baseball_sim` previously triggered the GUI bootstrap
+    immediately via ``from baseball_sim.app.main import main``.  This eager
+    import pulled in optional dependencies such as tkinter, pandas or even the
+    machine learning tooling used for offline model training.  The web API only
+    needs lightweight helpers, so the eager import prevented the Flask app from
+    starting unless every optional dependency was available.
+
+    By resolving the actual ``main`` function lazily we keep backwards
+    compatibility—``baseball_sim.main()`` continues to work—while avoiding the
+    side effects when the package is imported for non-GUI contexts.
+    """
+
+    from baseball_sim.app.main import main as _main  # local import to avoid eager dependency loading
+    return _main(*args, **kwargs)

--- a/baseball_sim/ui/web/__init__.py
+++ b/baseball_sim/ui/web/__init__.py
@@ -1,3 +1,23 @@
 """Browser-based user interface for the baseball simulator."""
 
-from .app import create_app  # noqa: F401
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["create_app"]
+
+
+def create_app(*args: Any, **kwargs: Any):
+    """Factory wrapper that imports Flask lazily.
+
+    Importing :mod:`baseball_sim.ui.web` used to require Flask immediately,
+    which made it impossible to access helper utilities (such as the
+    :class:`~baseball_sim.ui.web.session.WebGameSession`) in environments where
+    Flask is not installed.  The web UI only needs Flask when the application is
+    actually instantiated, so we defer the import until this function is
+    executed.
+    """
+
+    from .app import create_app as _create_app
+
+    return _create_app(*args, **kwargs)

--- a/prediction_models/prediction.py
+++ b/prediction_models/prediction.py
@@ -1,92 +1,101 @@
-import pandas as pd
-from sklearn.linear_model import LinearRegression
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import mean_squared_error
-from pybaseball import batting_stats
-import joblib
-import os
-import numpy as np
-import torch
-import torch.nn as nn
+"""Lightweight helpers for batting outcome prediction models."""
 
-# NNモデルの定義（pred_NN.pyから移植）
-class Net(nn.Module):
-    def __init__(self, input_dim=4, output_dim=5):
-        super(Net, self).__init__()
-        self.fc1 = nn.Linear(input_dim, 128)
-        self.fc2 = nn.Linear(128, 64)
-        self.fc3 = nn.Linear(64, output_dim)
-    
-    def forward(self, x):
-        x = torch.relu(self.fc1(x))
-        x = torch.relu(self.fc2(x))
-        x = self.fc3(x)
-        return x
+from __future__ import annotations
 
-def predict(model, sample):
-    """
-    sample は {'K%': ..., 'BB%': ..., 'Hard%': ..., 'GB%': ...} の形式。
-    1選手分の予測値を返す。
-    線形回帰モデル用の関数（後方互換性のため）
-    """
-    # 入力データの検証
-    required_features = ['K%', 'BB%', 'Hard%', 'GB%']
-    for feature in required_features:
+from typing import Iterable, List, Sequence
+
+try:  # pragma: no cover - optional dependency
+    import torch  # type: ignore
+    import torch.nn as nn  # type: ignore
+except ImportError:  # pragma: no cover - fallback when PyTorch is unavailable
+    torch = None  # type: ignore
+    nn = None  # type: ignore
+
+REQUIRED_FEATURES: Sequence[str] = ("K%", "BB%", "Hard%", "GB%")
+
+
+if nn is not None:
+
+    class Net(nn.Module):
+        """Simple feed-forward network used for probability prediction."""
+
+        def __init__(self, input_dim: int = 4, output_dim: int = 5) -> None:
+            super().__init__()
+            self.fc1 = nn.Linear(input_dim, 128)
+            self.fc2 = nn.Linear(128, 64)
+            self.fc3 = nn.Linear(64, output_dim)
+
+        def forward(self, x):  # type: ignore[override]
+            x = torch.relu(self.fc1(x))
+            x = torch.relu(self.fc2(x))
+            return self.fc3(x)
+
+else:  # pragma: no cover - PyTorch not installed
+
+    class Net:  # type: ignore[too-few-public-methods]
+        """Placeholder used when PyTorch is not available."""
+
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - simple message
+            raise RuntimeError("PyTorch is required to instantiate Net")
+
+        def forward(self, x):  # pragma: no cover - never called without torch
+            raise RuntimeError("PyTorch is required to use Net")
+
+
+def _extract_features(sample: dict) -> List[float]:
+    """Return the feature vector expected by the prediction models."""
+
+    values: List[float] = []
+    for feature in REQUIRED_FEATURES:
         if feature not in sample:
             raise ValueError(f"必須特徴量 '{feature}' が入力に含まれていません。")
-    
-    X_new = pd.DataFrame([sample])
-    return model.predict(X_new)[0]
+        values.append(float(sample[feature]))
+    return values
 
-def predict_linear(model, sample):
-    """
-    線形回帰モデル用の予測関数
-    """
+
+def predict(model, sample: dict) -> Iterable[float]:
+    """Predict the outcome distribution using a scikit-learn compatible model."""
+
+    if not hasattr(model, "predict"):
+        raise AttributeError("Model does not provide a predict() method")
+    feature_vector = _extract_features(sample)
+    prediction = model.predict([feature_vector])
+    return prediction[0]
+
+
+def predict_linear(model, sample: dict) -> Iterable[float]:
+    """Alias kept for backwards compatibility with legacy callers."""
+
     return predict(model, sample)
 
-def predict_nn(model, sample):
-    """
-    ニューラルネットワークモデル用の予測関数
-    sample は {'K%': ..., 'BB%': ..., 'Hard%': ..., 'GB%': ...} の形式。
-    1選手分の予測値を返す。
-    """
-    # 入力データの検証
-    required_features = ['K%', 'BB%', 'Hard%', 'GB%']
-    for feature in required_features:
-        if feature not in sample:
-            raise ValueError(f"必須特徴量 '{feature}' が入力に含まれていません。")
-    
-    # データを配列に変換
-    X_new = pd.DataFrame([sample]).values.astype(np.float32)
-    tensor_input = torch.from_numpy(X_new)
-    
+
+def predict_nn(model, sample: dict) -> Iterable[float]:
+    """Run the neural network model if PyTorch is available."""
+
+    if torch is None:
+        raise RuntimeError("PyTorch is required for neural network predictions")
+
+    feature_vector = _extract_features(sample)
+    tensor_input = torch.tensor([feature_vector], dtype=torch.float32)
+
     model.eval()
     with torch.no_grad():
-        prediction = model(tensor_input).numpy()
-    
-    return prediction[0]  # 出力は5要素のベクトル
+        prediction = model(tensor_input)
 
-def predict_auto(model, sample, model_type='linear'):
-    """
-    モデルタイプに応じて適切な予測関数を呼び出す
-    
-    Parameters:
-    -----------
-    model : sklearn model or torch model
-        予測に使用するモデル
-    sample : dict
-        特徴量のディクショナリ {'K%': ..., 'BB%': ..., 'Hard%': ..., 'GB%': ...}
-    model_type : str
-        'linear' または 'nn'
-    
-    Returns:
-    --------
-    numpy.ndarray
-        予測結果（5要素のベクトル）
-    """
-    if model_type == 'linear':
+    result = prediction.squeeze(0)
+    if hasattr(result, "tolist"):
+        return result.tolist()
+    return [float(value) for value in result]
+
+
+def predict_auto(model, sample: dict, model_type: str = "linear") -> Iterable[float]:
+    """Dispatch prediction to the appropriate helper based on model type."""
+
+    if model_type == "linear":
         return predict_linear(model, sample)
-    elif model_type == 'nn':
+    if model_type == "nn":
         return predict_nn(model, sample)
-    else:
-        raise ValueError(f"Unsupported model type: {model_type}")
+    raise ValueError(f"Unsupported model type: {model_type}")
+
+
+__all__ = ["Net", "predict", "predict_linear", "predict_nn", "predict_auto"]


### PR DESCRIPTION
## Summary
- lazily load the CLI entry point so importing `baseball_sim` no longer requires every optional GUI dependency
- rework the web package and prediction helpers to defer Flask/PyTorch imports until they are actually needed
- degrade the batting model loader when joblib or PyTorch is absent so the API can fall back to the default probabilities

## Testing
- python -m compileall baseball_sim prediction_models
- python - <<'PY'
from baseball_sim.ui.web.session import WebGameSession
session = WebGameSession()
state = session.start_new_game()
assert state['game']['active']
PY


------
https://chatgpt.com/codex/tasks/task_e_68d17ed3d3288322877b98fe6527c77c