### PR TITLE
Web UI: ラインナップ表示とスコアボードの改善

### DIFF
--- a/baseball_sim/ui/web/session.py
+++ b/baseball_sim/ui/web/session.py
@@ -594,6 +594,7 @@ class WebGameSession:
             is_offense = bool(self.game_state and self.game_state.batting_team is team)
             current_batter_index = team.current_batter_index if team.lineup else 0
             for index, player in enumerate(team.lineup):
+                summary = self._lineup_batter_summary(player)
                 lineup.append(
                     {
                         "index": index,
@@ -605,6 +606,9 @@ class WebGameSession:
                         "eligible_all": self._eligible_positions_raw(player),
                         "pitcher_type": getattr(player, "pitcher_type", None),
                         "is_current_batter": is_offense and index == current_batter_index,
+                        "avg": summary["avg"],
+                        "hr": summary["hr"],
+                        "rbi": summary["rbi"],
                     }
                 )
 
@@ -661,6 +665,21 @@ class WebGameSession:
             }
 
         return teams
+
+    def _lineup_batter_summary(self, player) -> Dict[str, object]:
+        if not player:
+            return {"avg": ".000", "hr": 0, "rbi": 0}
+
+        summary = self._serialize_batter_stats(player)
+        avg = summary.get("avg") or ".000"
+        hr = summary.get("hr")
+        rbi = summary.get("rbi")
+
+        return {
+            "avg": avg,
+            "hr": hr if hr is not None else 0,
+            "rbi": rbi if rbi is not None else 0,
+        }
 
     def _build_team_stats(self, team) -> Dict[str, List[Dict[str, object]]]:
         batting: List[Dict[str, object]] = []

--- a/baseball_sim/ui/web/static/styles.css
+++ b/baseball_sim/ui/web/static/styles.css
@@ -1016,6 +1016,23 @@ button:focus-visible {
   border-bottom: 1px solid rgba(148, 163, 184, 0.15);
 }
 
+.roster th.player-col,
+.roster td.player-name {
+  white-space: nowrap;
+}
+
+.roster td.player-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.roster th.stat-col,
+.roster td.stat-col {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
 .roster tbody tr.active {
   background: rgba(96, 165, 250, 0.12);
 }

--- a/baseball_sim/ui/web/templates/index.html
+++ b/baseball_sim/ui/web/templates/index.html
@@ -23,7 +23,7 @@
             </div>
           </div>
 
-          <div class="header-insights" id="insight-grid">
+          <div class="header-insights hidden" id="insight-grid">
             <article class="insight-card" data-insight="run-rate">
               <header class="insight-header">
                 <p class="insight-label">ランペース</p>
@@ -137,7 +137,14 @@
                   <h3>攻撃</h3>
                   <table>
                     <thead>
-                      <tr><th>#</th><th>Pos</th><th>選手</th><th>Eligible</th></tr>
+                      <tr>
+                        <th>#</th>
+                        <th>Pos</th>
+                        <th class="player-col">選手</th>
+                        <th class="stat-col">AVG</th>
+                        <th class="stat-col">HR</th>
+                        <th class="stat-col">RBI</th>
+                      </tr>
                     </thead>
                     <tbody></tbody>
                   </table>
@@ -150,7 +157,14 @@
                   <h3>守備</h3>
                   <table>
                     <thead>
-                      <tr><th>#</th><th>Pos</th><th>選手</th><th>Eligible</th></tr>
+                      <tr>
+                        <th>#</th>
+                        <th>Pos</th>
+                        <th class="player-col">選手</th>
+                        <th class="stat-col">AVG</th>
+                        <th class="stat-col">HR</th>
+                        <th class="stat-col">RBI</th>
+                      </tr>
                     </thead>
                     <tbody></tbody>
                   </table>


### PR DESCRIPTION
## Summary
- タイトル画面では分析カードを隠し、試合が始まってから表示するようにしました
- ラインナップ表から守備適性列を削除し、打率・本塁打・打点を表示して選手名を1行表示に整えました
- バッティング成績をバックエンドから渡し、表のプレー中はスコアボードの裏側を空欄にするよう調整しました

## Testing
- pytest *(依存ライブラリ joblib/torch が無いため失敗)*

------
https://chatgpt.com/codex/tasks/task_e_68d23c1b593083229ebd6c4ed5617804