### PR TITLE
Update web defensive substitution workflow

### DIFF
--- a/baseball_sim/ui/web/routes.py
+++ b/baseball_sim/ui/web/routes.py
@@ -86,15 +86,22 @@ def create_routes(session: WebGameSession) -> Blueprint:
     @api_bp.post("/strategy/defense_substitution")
     def defensive_substitution() -> Dict[str, Any]:
         payload = request.get_json(silent=True) or {}
-        lineup_index = parse_int_param(payload, "lineup_index")
-        bench_index = parse_int_param(payload, "bench_index")
-        try:
-            state = session.execute_defensive_substitution(
-                lineup_index=lineup_index,
-                bench_index=bench_index,
-            )
-        except GameSessionError as exc:
-            return create_error_response(str(exc), session)
+        swaps = payload.get("swaps")
+        if isinstance(swaps, list):
+            try:
+                state = session.execute_defensive_substitution(swaps=swaps)
+            except GameSessionError as exc:
+                return create_error_response(str(exc), session)
+        else:
+            lineup_index = parse_int_param(payload, "lineup_index")
+            bench_index = parse_int_param(payload, "bench_index")
+            try:
+                state = session.execute_defensive_substitution(
+                    lineup_index=lineup_index,
+                    bench_index=bench_index,
+                )
+            except GameSessionError as exc:
+                return create_error_response(str(exc), session)
         return jsonify(state)
 
     @api_bp.post("/strategy/change_pitcher")

--- a/baseball_sim/ui/web/state_builders.py
+++ b/baseball_sim/ui/web/state_builders.py
@@ -259,6 +259,19 @@ class SessionStateBuilder:
                     }
                 )
 
+            retired: List[Dict[str, object]] = []
+            for player in getattr(team, "ejected_players", []) or []:
+                retired.append(
+                    {
+                        "name": getattr(player, "name", "-"),
+                        "position": self._display_position(player),
+                        "position_key": self._defensive_position_key(player),
+                        "eligible": self._eligible_positions(player),
+                        "eligible_all": self._eligible_positions_raw(player),
+                        "pitcher_type": getattr(player, "pitcher_type", None),
+                    }
+                )
+
             pitchers: List[Dict[str, object]] = []
             seen_ids = set()
             if getattr(team, "current_pitcher", None):
@@ -289,6 +302,7 @@ class SessionStateBuilder:
                 "name": team.name,
                 "lineup": lineup,
                 "bench": bench,
+                "retired": retired,
                 "pitchers": pitchers,
                 "pitcher_options": pitcher_options,
                 "stats": self._build_team_stats(team),

--- a/baseball_sim/ui/web/static/css/modals.css
+++ b/baseball_sim/ui/web/static/css/modals.css
@@ -261,6 +261,35 @@
   background: rgba(239, 68, 68, 0.12);
 }
 
+.defense-retired {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.defense-retired .retired-card {
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  border-radius: 12px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--text-muted);
+}
+
+.defense-retired .retired-card strong {
+  color: var(--text);
+}
+
+.defense-retired .retired-card .retired-status {
+  font-size: 12px;
+  color: var(--danger);
+}
+
 .bench-card .eligible-label {
   font-size: 12px;
   color: var(--text-muted);
@@ -280,6 +309,18 @@
   margin: 0;
   color: var(--text-muted);
   font-size: 14px;
+}
+
+.selection-info.success {
+  color: var(--success);
+}
+
+.selection-info.danger {
+  color: var(--danger);
+}
+
+.selection-info.warning {
+  color: var(--warning);
 }
 
 .defense-actions {

--- a/baseball_sim/ui/web/static/js/controllers/events.js
+++ b/baseball_sim/ui/web/static/js/controllers/events.js
@@ -9,7 +9,7 @@ import {
 } from '../ui/menus.js';
 import { closeModal, openModal, resolveModal } from '../ui/modals.js';
 import { updateStatsPanel } from '../ui/renderers.js';
-import { handleDefenseBenchClick, handleDefenseFieldClick, updateDefenseSelectionInfo } from '../ui/defensePanel.js';
+import { handleDefensePlayerClick, updateDefenseSelectionInfo } from '../ui/defensePanel.js';
 
 export function initEventListeners(actions) {
   elements.startButton.addEventListener('click', () => actions.handleStart(false));
@@ -99,13 +99,13 @@ export function initEventListeners(actions) {
   }
 
   if (elements.defenseField) {
-    elements.defenseField.addEventListener('click', handleDefenseFieldClick);
+    elements.defenseField.addEventListener('click', handleDefensePlayerClick);
   }
   if (elements.defenseBench) {
-    elements.defenseBench.addEventListener('click', handleDefenseBenchClick);
+    elements.defenseBench.addEventListener('click', handleDefensePlayerClick);
   }
   if (elements.defenseExtras) {
-    elements.defenseExtras.addEventListener('click', handleDefenseBenchClick);
+    elements.defenseExtras.addEventListener('click', handleDefensePlayerClick);
   }
 
   elements.statsTeamButtons.forEach((button) => {

--- a/baseball_sim/ui/web/static/js/dom.js
+++ b/baseball_sim/ui/web/static/js/dom.js
@@ -48,6 +48,7 @@ export const elements = {
   defenseField: document.getElementById('defense-field'),
   defenseBench: document.getElementById('defense-bench-panel'),
   defenseExtras: document.getElementById('defense-extras'),
+  defenseRetired: document.getElementById('defense-retired-panel'),
   defenseSelectionInfo: document.getElementById('defense-selection-info'),
   pitcherSelect: document.getElementById('pitcher-select'),
   pitcherButton: document.getElementById('change-pitcher-button'),

--- a/baseball_sim/ui/web/static/js/state.js
+++ b/baseball_sim/ui/web/static/js/state.js
@@ -4,7 +4,8 @@ import { FIELD_POSITION_KEYS } from './config.js';
 
 export const stateCache = {
   data: null,
-  defenseSelection: { lineupIndex: null, benchIndex: null },
+  defensePlan: null,
+  defenseSelection: { first: null, feedback: null },
   defenseContext: { lineup: {}, bench: {}, canSub: false },
   currentBatterIndex: null,
   statsView: { team: 'away', type: 'batting' },
@@ -56,7 +57,7 @@ export function updateDefenseContext(lineupMap, benchMap, canSub) {
 }
 
 export function resetDefenseSelection() {
-  stateCache.defenseSelection = { lineupIndex: null, benchIndex: null };
+  stateCache.defenseSelection = { first: null, feedback: null };
 }
 
 export function isKnownFieldPosition(positionKey) {

--- a/baseball_sim/ui/web/static/js/ui/defensePanel.js
+++ b/baseball_sim/ui/web/static/js/ui/defensePanel.js
@@ -3,9 +3,6 @@ import { elements } from '../dom.js';
 import {
   stateCache,
   normalizePositionKey,
-  getLineupPlayer,
-  getBenchPlayer,
-  getLineupPositionKey,
   canBenchPlayerCoverPosition,
   updateDefenseContext,
   resetDefenseSelection,
@@ -13,20 +10,197 @@ import {
 } from '../state.js';
 import { escapeHtml, renderPositionList, renderPositionToken } from '../utils.js';
 
-export function renderDefensePanel(defenseTeam, gameState) {
-  const lineup = defenseTeam?.lineup || [];
-  const benchPlayers = defenseTeam?.bench || [];
+const DEFAULT_INFO = '出場中またはベンチの選手を2人選択すると入れ替えできます。';
 
+function buildPlanSignature(team) {
+  if (!team) return null;
+  const lineupSig = (team.lineup || [])
+    .map((player) => {
+      const key = normalizePositionKey(player?.position_key || player?.position) || '-';
+      return `${player?.index ?? ''}:${player?.name ?? ''}:${key}`;
+    })
+    .join('|');
+  const benchSig = (team.bench || [])
+    .map((player) => `${player?.index ?? ''}:${player?.name ?? ''}`)
+    .join('|');
+  const retiredSig = (team.retired || [])
+    .map((player) => player?.name ?? '')
+    .join('|');
+  return `${team.name || ''}::${lineupSig}::${benchSig}::${retiredSig}`;
+}
+
+function cloneLineupPlayer(player, index) {
+  const clone = {
+    ...player,
+    index,
+    order: index + 1,
+  };
+  const positionKey = normalizePositionKey(player?.position_key || player?.position);
+  clone.position_key = positionKey;
+  clone.position = player?.position ?? positionKey ?? '-';
+  const eligible = Array.isArray(player?.eligible) ? [...player.eligible] : [];
+  const eligibleAll = Array.isArray(player?.eligible_all)
+    ? [...player.eligible_all]
+    : eligible.map((pos) => String(pos).toUpperCase());
+  clone.eligible = eligible;
+  clone.eligible_all = eligibleAll;
+  return clone;
+}
+
+function cloneBenchPlayer(player, index) {
+  const clone = {
+    ...player,
+    index,
+  };
+  const eligible = Array.isArray(player?.eligible) ? [...player.eligible] : [];
+  const eligibleAll = Array.isArray(player?.eligible_all)
+    ? [...player.eligible_all]
+    : eligible.map((pos) => String(pos).toUpperCase());
+  clone.eligible = eligible;
+  clone.eligible_all = eligibleAll;
+  return clone;
+}
+
+function cloneRetiredPlayer(player) {
+  const clone = {
+    ...player,
+  };
+  const eligible = Array.isArray(player?.eligible) ? [...player.eligible] : [];
+  const eligibleAll = Array.isArray(player?.eligible_all)
+    ? [...player.eligible_all]
+    : eligible.map((pos) => String(pos).toUpperCase());
+  clone.eligible = eligible;
+  clone.eligible_all = eligibleAll;
+  clone.position = player?.position ?? player?.position_key ?? '-';
+  clone.position_key = normalizePositionKey(player?.position_key || player?.position);
+  return clone;
+}
+
+function clearDefensePanels() {
+  if (elements.defenseField) {
+    elements.defenseField.innerHTML = '';
+  }
+  if (elements.defenseExtras) {
+    elements.defenseExtras.classList.add('hidden');
+    elements.defenseExtras.innerHTML = '';
+  }
+  if (elements.defenseBench) {
+    elements.defenseBench.innerHTML = '';
+  }
+  if (elements.defenseRetired) {
+    elements.defenseRetired.classList.add('hidden');
+    elements.defenseRetired.innerHTML = '';
+  }
+}
+
+function reindexPlanPlayers(plan) {
+  if (!plan) return;
+  plan.lineup.forEach((player, index) => {
+    if (!player) return;
+    player.index = index;
+    player.order = index + 1;
+  });
+  plan.bench.forEach((player, index) => {
+    if (!player) return;
+    player.index = index;
+  });
+}
+
+function updateDefensePlanContext(plan) {
   const lineupMap = {};
-  lineup.forEach((player) => {
-    lineupMap[player.index] = player;
-  });
   const benchMap = {};
-  benchPlayers.forEach((player) => {
-    benchMap[player.index] = player;
+  (plan?.lineup || []).forEach((player, index) => {
+    if (player) {
+      lineupMap[index] = player;
+    }
   });
-
+  (plan?.bench || []).forEach((player, index) => {
+    if (player) {
+      benchMap[index] = player;
+    }
+  });
   updateDefenseContext(lineupMap, benchMap, stateCache.defenseContext.canSub);
+}
+
+function ensureDefensePlan(defenseTeam) {
+  if (!defenseTeam) {
+    stateCache.defensePlan = null;
+    resetDefenseSelection();
+    updateDefenseContext({}, {}, stateCache.defenseContext.canSub);
+    clearDefensePanels();
+    return null;
+  }
+
+  const signature = buildPlanSignature(defenseTeam);
+  if (!stateCache.defensePlan || stateCache.defensePlan.signature !== signature) {
+    const lineup = (defenseTeam.lineup || []).map((player, index) =>
+      cloneLineupPlayer(player, index),
+    );
+    const bench = (defenseTeam.bench || []).map((player, index) =>
+      cloneBenchPlayer(player, index),
+    );
+    const retired = (defenseTeam.retired || []).map((player) => cloneRetiredPlayer(player));
+
+    stateCache.defensePlan = {
+      signature,
+      teamName: defenseTeam.name || '',
+      lineup,
+      bench,
+      retired,
+      operations: [],
+    };
+    resetDefenseSelection();
+    reindexPlanPlayers(stateCache.defensePlan);
+    updateDefensePlanContext(stateCache.defensePlan);
+  } else {
+    updateDefensePlanContext(stateCache.defensePlan);
+  }
+
+  return stateCache.defensePlan;
+}
+
+function getCurrentGameState(gameState) {
+  if (gameState && typeof gameState === 'object') {
+    return gameState;
+  }
+  return stateCache.data?.game || {};
+}
+
+function renderRetiredList(container, retiredPlayers) {
+  if (!container) return;
+  container.innerHTML = '';
+  if (!retiredPlayers.length) {
+    container.classList.add('hidden');
+    return;
+  }
+
+  container.classList.remove('hidden');
+  const title = document.createElement('p');
+  title.className = 'extras-title';
+  title.textContent = 'リタイア選手';
+  container.appendChild(title);
+
+  retiredPlayers.forEach((player) => {
+    const card = document.createElement('div');
+    card.className = 'retired-card';
+    const retiredToken = renderPositionToken(player?.position || '-', player?.pitcher_type);
+    const eligibleHtml = renderPositionList(player?.eligible || [], player?.pitcher_type);
+    card.innerHTML = `
+      <strong>${escapeHtml(player?.name ?? '-')}</strong>
+      <span class="retired-status">${retiredToken ? `${retiredToken} 退場` : '退場'}</span>
+      <span class="eligible-label">適性</span>
+      <span class="eligible-positions">${eligibleHtml}</span>
+    `;
+    container.appendChild(card);
+  });
+}
+
+function renderDefensePlanView(plan, gameState) {
+  const lineup = plan?.lineup || [];
+  const benchPlayers = plan?.bench || [];
+  const retiredPlayers = plan?.retired || [];
+  const activeGame = Boolean(gameState?.active);
+  const canInteract = activeGame && stateCache.defenseContext.canSub;
 
   if (elements.defenseField) {
     elements.defenseField.innerHTML = '';
@@ -34,6 +208,7 @@ export function renderDefensePanel(defenseTeam, gameState) {
     const extras = [];
 
     lineup.forEach((player) => {
+      if (!player) return;
       const key = normalizePositionKey(player.position_key || player.position);
       if (key && isKnownFieldPosition(key) && !assigned.has(key)) {
         assigned.set(key, player);
@@ -48,21 +223,23 @@ export function renderDefensePanel(defenseTeam, gameState) {
       button.type = 'button';
       button.className = `position-slot ${slot.className}`;
       button.dataset.position = slot.key;
-      const labelHtml = renderPositionToken(slot.label, null, 'position-label');
+      button.dataset.role = 'lineup';
       if (player) {
-        button.dataset.lineupIndex = player.index;
+        button.dataset.index = String(player.index);
+        button.dataset.lineupIndex = String(player.index);
         const eligibleHtml = renderPositionList(player.eligible || [], player.pitcher_type);
         button.innerHTML = `
-          ${labelHtml}
+          ${renderPositionToken(slot.label, null, 'position-label')}
           <strong>${escapeHtml(player.name ?? '-')}</strong>
           <span class="eligible-positions">${eligibleHtml}</span>
         `;
-        button.disabled = !gameState.active;
+        button.disabled = !canInteract;
       } else {
+        button.dataset.index = '';
         button.dataset.lineupIndex = '';
         const emptyEligible = renderPositionList([], null);
         button.innerHTML = `
-          ${labelHtml}
+          ${renderPositionToken(slot.label, null, 'position-label')}
           <strong>空席</strong>
           <span class="eligible-positions">${emptyEligible}</span>
         `;
@@ -83,7 +260,9 @@ export function renderDefensePanel(defenseTeam, gameState) {
           const button = document.createElement('button');
           button.type = 'button';
           button.className = 'bench-card';
-          button.dataset.lineupIndex = player.index;
+          button.dataset.role = 'lineup';
+          button.dataset.index = String(player.index);
+          button.dataset.lineupIndex = String(player.index);
           const currentPosition = player.position && player.position !== '-' ? player.position : '-';
           const currentPositionHtml = renderPositionToken(currentPosition, player.pitcher_type);
           const eligibleHtml = renderPositionList(player.eligible || [], player.pitcher_type);
@@ -92,7 +271,7 @@ export function renderDefensePanel(defenseTeam, gameState) {
             <span class="eligible-label">現在: ${currentPositionHtml}</span>
             <span class="eligible-positions">適性: ${eligibleHtml}</span>
           `;
-          button.disabled = !gameState.active;
+          button.disabled = !canInteract;
           elements.defenseExtras.appendChild(button);
         });
       } else {
@@ -114,57 +293,225 @@ export function renderDefensePanel(defenseTeam, gameState) {
         const button = document.createElement('button');
         button.type = 'button';
         button.className = 'bench-card';
-        button.dataset.benchIndex = player.index;
+        button.dataset.role = 'bench';
+        button.dataset.index = String(player.index);
+        button.dataset.benchIndex = String(player.index);
         const eligibleHtml = renderPositionList(player.eligible || [], player.pitcher_type);
         button.innerHTML = `
           <strong>${escapeHtml(player.name ?? '-')}</strong>
           <span class="eligible-label">守備適性</span>
           <span class="eligible-positions">${eligibleHtml}</span>
         `;
-        button.disabled = !(gameState.active && stateCache.defenseContext.canSub);
+        button.disabled = !stateCache.defenseContext.canSub;
         elements.defenseBench.appendChild(button);
       });
     }
   }
 
-  updateDefenseBenchAvailability();
-  applyDefenseSelectionHighlights();
+  if (elements.defenseRetired) {
+    renderRetiredList(elements.defenseRetired, retiredPlayers);
+  }
+}
+
+function setDefenseFeedback(message, variant = 'info') {
+  if (message) {
+    stateCache.defenseSelection.feedback = { message, variant };
+  } else {
+    stateCache.defenseSelection.feedback = null;
+  }
+}
+
+function getPlanLineupPlayer(index) {
+  const plan = stateCache.defensePlan;
+  if (!plan) return null;
+  if (!Number.isInteger(index) || index < 0 || index >= plan.lineup.length) return null;
+  return plan.lineup[index] || null;
+}
+
+function getPlanBenchPlayer(index) {
+  const plan = stateCache.defensePlan;
+  if (!plan) return null;
+  if (!Number.isInteger(index) || index < 0 || index >= plan.bench.length) return null;
+  return plan.bench[index] || null;
+}
+
+function swapLineupPositions(plan, indexA, indexB) {
+  if (!Number.isInteger(indexA) || !Number.isInteger(indexB)) {
+    return { success: false, message: '選択された守備位置が無効です。', variant: 'danger' };
+  }
+  if (indexA === indexB) {
+    return { success: false, message: null };
+  }
+
+  const playerA = getPlanLineupPlayer(indexA);
+  const playerB = getPlanLineupPlayer(indexB);
+  if (!playerA || !playerB) {
+    return { success: false, message: '守備位置の情報を取得できませんでした。', variant: 'danger' };
+  }
+
+  const posAKey = normalizePositionKey(playerA.position_key || playerA.position);
+  const posBKey = normalizePositionKey(playerB.position_key || playerB.position);
+  const displayPosA = playerA.position || posAKey || '-';
+  const displayPosB = playerB.position || posBKey || '-';
+
+  if (posBKey && !canBenchPlayerCoverPosition(playerA, posBKey)) {
+    return {
+      success: false,
+      message: `${playerA.name} は ${displayPosB} を守れません。`,
+      variant: 'danger',
+    };
+  }
+  if (posAKey && !canBenchPlayerCoverPosition(playerB, posAKey)) {
+    return {
+      success: false,
+      message: `${playerB.name} は ${displayPosA} を守れません。`,
+      variant: 'danger',
+    };
+  }
+
+  playerA.position = displayPosB;
+  playerA.position_key = posBKey;
+  playerB.position = displayPosA;
+  playerB.position_key = posAKey;
+
+  plan.operations.push({
+    type: 'lineup_lineup',
+    lineupIndexA: indexA,
+    lineupIndexB: indexB,
+  });
+
+  return {
+    success: true,
+    message: `${playerA.name} と ${playerB.name} の守備位置を入れ替える案を追加しました。`,
+    variant: 'success',
+  };
+}
+
+function swapBenchWithLineup(plan, lineupIndex, benchIndex) {
+  const lineupPlayer = getPlanLineupPlayer(lineupIndex);
+  const benchPlayer = getPlanBenchPlayer(benchIndex);
+  if (!lineupPlayer || !benchPlayer) {
+    return {
+      success: false,
+      message: '交代対象の選手情報を取得できませんでした。',
+      variant: 'danger',
+    };
+  }
+
+  const positionKey = normalizePositionKey(lineupPlayer.position_key || lineupPlayer.position);
+  const positionLabel = lineupPlayer.position || positionKey || '守備位置';
+
+  if (positionKey && !canBenchPlayerCoverPosition(benchPlayer, positionKey)) {
+    return {
+      success: false,
+      message: `${benchPlayer.name} は ${positionLabel} を守れません。別の選手を選択してください。`,
+      variant: 'danger',
+    };
+  }
+
+  const entering = cloneBenchPlayer(benchPlayer, lineupIndex);
+  entering.order = lineupIndex + 1;
+  entering.position_key = positionKey;
+  entering.position = positionLabel;
+
+  plan.bench.splice(benchIndex, 1);
+  plan.lineup[lineupIndex] = entering;
+
+  const retiredEntry = cloneRetiredPlayer(lineupPlayer);
+  if (retiredEntry.name) {
+    plan.retired.push(retiredEntry);
+  }
+
+  plan.operations.push({
+    type: 'bench_lineup',
+    lineupIndex,
+    benchIndex,
+  });
+
+  return {
+    success: true,
+    message: `${entering.name} を ${positionLabel} に投入する案を追加しました（${lineupPlayer.name} はリタイア）。`,
+    variant: 'success',
+  };
+}
+
+function applyDefenseSwap(first, second) {
+  if (!stateCache.defenseContext.canSub) {
+    return { success: false, message: '守備交代は現在行えません。', variant: 'danger' };
+  }
+  const plan = stateCache.defensePlan;
+  if (!plan) {
+    return { success: false, message: '守備情報がありません。', variant: 'danger' };
+  }
+
+  if (!first || !second) {
+    return { success: false, message: null };
+  }
+
+  if (first.type === second.type && first.index === second.index) {
+    return { success: false, message: null };
+  }
+
+  if (first.type === 'lineup' && second.type === 'lineup') {
+    return swapLineupPositions(plan, first.index, second.index);
+  }
+
+  if ((first.type === 'lineup' && second.type === 'bench') || (first.type === 'bench' && second.type === 'lineup')) {
+    const lineupIndex = first.type === 'lineup' ? first.index : second.index;
+    const benchIndex = first.type === 'bench' ? first.index : second.index;
+    return swapBenchWithLineup(plan, lineupIndex, benchIndex);
+  }
+
+  return {
+    success: false,
+    message: '選択した組み合わせでは入れ替えできません。',
+    variant: 'danger',
+  };
+}
+
+function commitDefensePlanChange(plan, gameState) {
+  reindexPlanPlayers(plan);
+  updateDefensePlanContext(plan);
+  renderDefensePlanView(plan, gameState);
+}
+
+export function renderDefensePanel(defenseTeam, gameState) {
+  const plan = ensureDefensePlan(defenseTeam);
+  if (!plan) {
+    return;
+  }
+  const currentGame = getCurrentGameState(gameState);
+  renderDefensePlanView(plan, currentGame);
 }
 
 export function updateDefenseBenchAvailability() {
   if (!elements.defenseBench) return;
 
-  const lineupPlayer = getLineupPlayer(stateCache.defenseSelection.lineupIndex);
-  const lineupPositionKey = getLineupPositionKey(lineupPlayer);
-  const positionLabel = lineupPlayer ? lineupPlayer.position || lineupPositionKey || '' : '';
+  const plan = stateCache.defensePlan;
+  const selection = stateCache.defenseSelection.first;
   const canSubBase = stateCache.defenseContext.canSub;
+  const hasLineupSelection = selection && selection.type === 'lineup';
+  const lineupPlayer = hasLineupSelection ? getPlanLineupPlayer(selection.index) : null;
+  const lineupPositionKey = lineupPlayer
+    ? normalizePositionKey(lineupPlayer.position_key || lineupPlayer.position)
+    : null;
+  const positionLabel = lineupPlayer ? lineupPlayer.position || lineupPositionKey || '' : '';
 
-  elements.defenseBench.querySelectorAll('[data-bench-index]').forEach((button) => {
-    const benchValue = button.dataset.benchIndex;
-    const benchIndex = Number(benchValue);
-    const benchPlayer = Number.isInteger(benchIndex) ? getBenchPlayer(benchIndex) : null;
+  elements.defenseBench.querySelectorAll('[data-role="bench"]').forEach((button) => {
+    const value = button.dataset.index ?? button.dataset.benchIndex;
+    const benchIndex = Number(value);
+    const benchPlayer = plan && Number.isInteger(benchIndex) ? plan.bench[benchIndex] : null;
 
-    const hasLineupSelection = Boolean(lineupPlayer);
-    const hasBenchPlayer = Boolean(benchPlayer);
-    let eligibleForPosition = false;
-    if (canSubBase && hasLineupSelection && hasBenchPlayer) {
-      if (lineupPositionKey) {
-        eligibleForPosition = canBenchPlayerCoverPosition(benchPlayer, lineupPositionKey);
-      } else {
-        eligibleForPosition = true;
-      }
+    let enable = canSubBase && Boolean(benchPlayer);
+    let markIneligible = false;
+
+    if (enable && hasLineupSelection && lineupPositionKey) {
+      enable = canBenchPlayerCoverPosition(benchPlayer, lineupPositionKey);
+      markIneligible = !enable;
     }
 
-    const enableButton = canSubBase && hasLineupSelection && hasBenchPlayer && eligibleForPosition;
-    const markIneligible =
-      canSubBase && hasLineupSelection && hasBenchPlayer && Boolean(lineupPositionKey) && !eligibleForPosition;
-
-    button.disabled = !enableButton;
+    button.disabled = !enable;
     button.classList.toggle('ineligible', markIneligible);
-
-    if (!enableButton && stateCache.defenseSelection.benchIndex === benchIndex) {
-      stateCache.defenseSelection.benchIndex = null;
-    }
 
     let hint = button.querySelector('.ineligible-hint');
     if (markIneligible) {
@@ -189,28 +536,33 @@ export function updateDefenseBenchAvailability() {
 }
 
 export function applyDefenseSelectionHighlights() {
-  const { lineupIndex, benchIndex } = stateCache.defenseSelection;
+  const selection = stateCache.defenseSelection.first;
+  const lineupTarget = selection && selection.type === 'lineup' ? selection.index : null;
+  const benchTarget = selection && selection.type === 'bench' ? selection.index : null;
+
   if (elements.defenseField) {
-    elements.defenseField.querySelectorAll('[data-lineup-index]').forEach((button) => {
-      const value = button.dataset.lineupIndex;
+    elements.defenseField.querySelectorAll('[data-role="lineup"]').forEach((button) => {
+      const value = button.dataset.index ?? button.dataset.lineupIndex;
       const index = Number(value);
-      const isSelected = value !== undefined && value !== '' && Number.isInteger(index) && index === lineupIndex;
+      const isSelected = Number.isInteger(index) && index === lineupTarget;
       button.classList.toggle('selected', isSelected);
     });
   }
+
   if (elements.defenseExtras) {
-    elements.defenseExtras.querySelectorAll('[data-lineup-index]').forEach((button) => {
-      const value = button.dataset.lineupIndex;
+    elements.defenseExtras.querySelectorAll('[data-role="lineup"]').forEach((button) => {
+      const value = button.dataset.index ?? button.dataset.lineupIndex;
       const index = Number(value);
-      const isSelected = value !== undefined && value !== '' && Number.isInteger(index) && index === lineupIndex;
+      const isSelected = Number.isInteger(index) && index === lineupTarget;
       button.classList.toggle('selected', isSelected);
     });
   }
+
   if (elements.defenseBench) {
-    elements.defenseBench.querySelectorAll('[data-bench-index]').forEach((button) => {
-      const value = button.dataset.benchIndex;
+    elements.defenseBench.querySelectorAll('[data-role="bench"]').forEach((button) => {
+      const value = button.dataset.index ?? button.dataset.benchIndex;
       const index = Number(value);
-      const isSelected = value !== undefined && value !== '' && Number.isInteger(index) && index === benchIndex;
+      const isSelected = Number.isInteger(index) && index === benchTarget;
       button.classList.toggle('selected', isSelected);
     });
   }
@@ -220,37 +572,48 @@ export function updateDefenseSelectionInfo() {
   updateDefenseBenchAvailability();
 
   const infoEl = elements.defenseSelectionInfo;
-  const { lineupIndex, benchIndex } = stateCache.defenseSelection;
-  const lineupPlayer = getLineupPlayer(lineupIndex);
-  const benchPlayer = getBenchPlayer(benchIndex);
-  const lineupPositionKey = getLineupPositionKey(lineupPlayer);
-  const positionLabel = lineupPlayer ? lineupPlayer.position || lineupPositionKey || '指定ポジション' : '';
+  if (!infoEl) return;
 
-  let benchEligible = true;
-  if (lineupPlayer && benchPlayer && lineupPositionKey) {
-    benchEligible = canBenchPlayerCoverPosition(benchPlayer, lineupPositionKey);
+  const plan = stateCache.defensePlan;
+  const selection = stateCache.defenseSelection.first;
+  const feedback = stateCache.defenseSelection.feedback;
+  const canSub = stateCache.defenseContext.canSub;
+  const operationsCount = plan?.operations?.length || 0;
+
+  infoEl.classList.remove('success', 'danger', 'warning');
+
+  let message = DEFAULT_INFO;
+  let variantClass = null;
+
+  if (feedback?.message) {
+    message = feedback.message;
+    variantClass = feedback.variant && feedback.variant !== 'info' ? feedback.variant : null;
+  } else if (!canSub) {
+    message = '守備交代を行える状況ではありません。';
+    variantClass = 'warning';
+  } else if (!plan || !(plan.lineup || []).length) {
+    message = '守備情報がありません。';
+  } else if (selection?.type === 'lineup') {
+    const player = getPlanLineupPlayer(selection.index);
+    message = player
+      ? `${player.name} と入れ替える選手を選択してください。`
+      : '守備交代を行う守備位置を選択してください。';
+  } else if (selection?.type === 'bench') {
+    const player = getPlanBenchPlayer(selection.index);
+    message = player
+      ? `${player.name} を投入する守備位置を選択してください。`
+      : '守備交代を行う守備位置を選択してください。';
+  } else if (operationsCount > 0) {
+    message = `未適用の守備交代案が ${operationsCount} 件あります。適用ボタンで確定してください。`;
+    variantClass = 'warning';
   }
 
-  if (infoEl) {
-    if (!stateCache.defenseContext.canSub) {
-      infoEl.textContent = '守備交代を行える状況ではありません。';
-    } else if (!lineupPlayer && !benchPlayer) {
-      infoEl.textContent = '守備交代を行う守備位置とベンチ選手を選択してください。';
-    } else if (!lineupPlayer) {
-      infoEl.textContent = benchPlayer
-        ? `${benchPlayer.name} を投入する守備位置を選択してください。`
-        : '守備交代を行う守備位置を選択してください。';
-    } else if (!benchPlayer) {
-      infoEl.textContent = `${lineupPlayer.name} を交代させる選手を選択してください。`;
-    } else if (lineupPositionKey && !benchEligible) {
-      infoEl.textContent = `${benchPlayer.name} は ${positionLabel} を守れません。別の選手を選択してください。`;
-    } else {
-      infoEl.textContent = `${lineupPlayer.name} ↔ ${benchPlayer.name} の守備交代を実行できます。`;
-    }
+  infoEl.textContent = message;
+  if (variantClass) {
+    infoEl.classList.add(variantClass);
   }
 
-  const canApply =
-    stateCache.defenseContext.canSub && Boolean(lineupPlayer) && Boolean(benchPlayer) && (!lineupPositionKey || benchEligible);
+  const canApply = canSub && operationsCount > 0;
   if (elements.defenseApplyButton) {
     elements.defenseApplyButton.disabled = !canApply;
   }
@@ -258,50 +621,66 @@ export function updateDefenseSelectionInfo() {
   applyDefenseSelectionHighlights();
 }
 
-export function handleDefenseFieldClick(event) {
-  const button = event.target.closest('button[data-lineup-index]');
+export function handleDefensePlayerClick(event) {
+  const button = event.target.closest('[data-role]');
   if (!button || button.disabled) return;
-  const value = button.dataset.lineupIndex;
-  if (value === undefined || value === '') return;
-  const index = Number(value);
-  if (Number.isNaN(index)) return;
-  stateCache.defenseSelection.lineupIndex = index;
-  applyDefenseSelectionHighlights();
-  updateDefenseSelectionInfo();
-}
 
-export function handleDefenseBenchClick(event) {
-  const lineupButton = event.target.closest('button[data-lineup-index]');
-  if (lineupButton && !lineupButton.disabled) {
-    const value = lineupButton.dataset.lineupIndex;
-    if (value !== undefined && value !== '') {
-      const index = Number(value);
-      if (!Number.isNaN(index)) {
-        stateCache.defenseSelection.lineupIndex = index;
-        applyDefenseSelectionHighlights();
-        updateDefenseSelectionInfo();
-        return;
-      }
-    }
+  const role = button.dataset.role;
+  if (!role || (role !== 'lineup' && role !== 'bench')) return;
+
+  const value =
+    role === 'lineup'
+      ? button.dataset.index ?? button.dataset.lineupIndex
+      : button.dataset.index ?? button.dataset.benchIndex;
+  const index = Number(value);
+  if (!Number.isInteger(index) || index < 0) return;
+
+  const currentSelection = stateCache.defenseSelection.first;
+
+  if (currentSelection && currentSelection.type === role && currentSelection.index === index) {
+    stateCache.defenseSelection.first = null;
+    setDefenseFeedback(null);
+    applyDefenseSelectionHighlights();
+    updateDefenseSelectionInfo();
+    return;
   }
 
-  const benchButton = event.target.closest('button[data-bench-index]');
-  if (!benchButton || benchButton.disabled) return;
-  const benchValue = benchButton.dataset.benchIndex;
-  if (benchValue === undefined || benchValue === '') return;
-  const benchIndex = Number(benchValue);
-  if (Number.isNaN(benchIndex)) return;
-  stateCache.defenseSelection.benchIndex = benchIndex;
+  if (!currentSelection) {
+    stateCache.defenseSelection.first = { type: role, index };
+    setDefenseFeedback(null);
+    applyDefenseSelectionHighlights();
+    updateDefenseSelectionInfo();
+    return;
+  }
+
+  const result = applyDefenseSwap(currentSelection, { type: role, index });
+  if (result.success) {
+    const plan = stateCache.defensePlan;
+    stateCache.defenseSelection.first = null;
+    setDefenseFeedback(result.message, result.variant || 'success');
+    commitDefensePlanChange(plan, getCurrentGameState());
+  } else if (result.message) {
+    setDefenseFeedback(result.message, result.variant || 'danger');
+  }
+
   applyDefenseSelectionHighlights();
   updateDefenseSelectionInfo();
 }
 
 export function resetDefenseSelectionsIfUnavailable(defenseLineup, defenseBenchPlayers) {
-  if (!defenseLineup.some((player) => player.index === stateCache.defenseSelection.lineupIndex)) {
-    stateCache.defenseSelection.lineupIndex = null;
-  }
-  if (!defenseBenchPlayers.some((player) => player.index === stateCache.defenseSelection.benchIndex)) {
-    stateCache.defenseSelection.benchIndex = null;
+  const selection = stateCache.defenseSelection.first;
+  if (!selection) return;
+
+  if (
+    selection.type === 'lineup' &&
+    (!Array.isArray(defenseLineup) || selection.index < 0 || selection.index >= defenseLineup.length)
+  ) {
+    resetDefenseSelection();
+  } else if (
+    selection.type === 'bench' &&
+    (!Array.isArray(defenseBenchPlayers) || selection.index < 0 || selection.index >= defenseBenchPlayers.length)
+  ) {
+    resetDefenseSelection();
   }
 }
 

--- a/baseball_sim/ui/web/templates/index.html
+++ b/baseball_sim/ui/web/templates/index.html
@@ -275,6 +275,9 @@
           <div class="defense-section">
             <h4>ベンチ</h4>
             <div class="defense-bench" id="defense-bench-panel"></div>
+            <div class="defense-retired hidden" id="defense-retired-panel">
+              <p class="extras-title">リタイア選手</p>
+            </div>
           </div>
         </div>
         <div class="modal-footer defense-footer">


### PR DESCRIPTION
## Summary
- allow the web defense modal to stage arbitrary two-player swaps, track pending operations, and show retired players
- accept swap plans on the backend and execute them sequentially while preserving lineup validation warnings
- add UI affordances, styling, and messaging for the new retired list and multi-swap workflow

## Testing
- pytest *(fails: joblib and torch are not installed in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2529e467483228e61434361d01bc0