### PR TITLE
Allow forced defensive swaps in web UI

### DIFF
--- a/baseball_sim/ui/web/routes.py
+++ b/baseball_sim/ui/web/routes.py
@@ -87,9 +87,10 @@ def create_routes(session: WebGameSession) -> Blueprint:
     def defensive_substitution() -> Dict[str, Any]:
         payload = request.get_json(silent=True) or {}
         swaps = payload.get("swaps")
+        force = bool(payload.get("force"))
         if isinstance(swaps, list):
             try:
-                state = session.execute_defensive_substitution(swaps=swaps)
+                state = session.execute_defensive_substitution(swaps=swaps, force_illegal=force)
             except GameSessionError as exc:
                 return create_error_response(str(exc), session)
         else:
@@ -99,6 +100,7 @@ def create_routes(session: WebGameSession) -> Blueprint:
                 state = session.execute_defensive_substitution(
                     lineup_index=lineup_index,
                     bench_index=bench_index,
+                    force_illegal=force,
                 )
             except GameSessionError as exc:
                 return create_error_response(str(exc), session)

--- a/baseball_sim/ui/web/session.py
+++ b/baseball_sim/ui/web/session.py
@@ -263,6 +263,7 @@ class WebGameSession:
         lineup_index: Optional[int] = None,
         bench_index: Optional[int] = None,
         swaps: Optional[List[Dict[str, Any]]] = None,
+        force_illegal: bool = False,
     ) -> Dict[str, object]:
         """Swap defensive players according to the provided instruction."""
 
@@ -272,12 +273,14 @@ class WebGameSession:
         substitution_manager = SubstitutionManager(self.game_state.fielding_team)
 
         if swaps is not None:
-            success, message = substitution_manager.execute_defensive_plan(swaps)
+            success, message = substitution_manager.execute_defensive_plan(
+                swaps, allow_illegal=force_illegal
+            )
         else:
             if lineup_index is None or bench_index is None:
                 raise GameSessionError("Invalid defensive substitution request.")
             success, message = substitution_manager.execute_defensive_substitution(
-                bench_index, lineup_index
+                bench_index, lineup_index, allow_illegal=force_illegal
             )
 
         self._notifications.publish("success" if success else "danger", message)

--- a/baseball_sim/ui/web/static/js/state.js
+++ b/baseball_sim/ui/web/static/js/state.js
@@ -48,6 +48,32 @@ export function canBenchPlayerCoverPosition(benchPlayer, positionKey) {
   return eligiblePositions.includes(positionKey);
 }
 
+export function getDefensePlanInvalidAssignments(plan) {
+  if (!plan || !Array.isArray(plan.lineup)) {
+    return [];
+  }
+
+  const invalid = [];
+  plan.lineup.forEach((player, index) => {
+    if (!player) return;
+    const positionKey = normalizePositionKey(player.position_key || player.position);
+    if (!positionKey || positionKey === '-') {
+      return;
+    }
+
+    if (!canBenchPlayerCoverPosition(player, positionKey)) {
+      invalid.push({
+        index,
+        player,
+        positionKey,
+        positionLabel: player.position || positionKey,
+      });
+    }
+  });
+
+  return invalid;
+}
+
 export function updateDefenseContext(lineupMap, benchMap, canSub) {
   stateCache.defenseContext = {
     lineup: lineupMap,


### PR DESCRIPTION
## Summary
- relax the defense panel swap validation so users can queue ineligible alignments, surface inline warnings, and require confirmation when applying
- send a force flag from the web client and update the backend routes/session to accept it for defensive plans
- allow the substitution manager and team routines to bypass position eligibility when forced so invalid alignments can be committed

## Testing
- pytest *(fails: missing optional dependencies joblib and torch)*

------
https://chatgpt.com/codex/tasks/task_e_68d262b4f07483228189874024815783