### PR TITLE
Add reset option to defense substitution modal

### DIFF
--- a/baseball_sim/ui/web/static/js/controllers/actions.js
+++ b/baseball_sim/ui/web/static/js/controllers/actions.js
@@ -2,6 +2,7 @@ import { CONFIG } from '../config.js';
 import { elements } from '../dom.js';
 import { stateCache, resetDefenseSelection, getDefensePlanInvalidAssignments } from '../state.js';
 import { apiRequest } from '../services/apiClient.js';
+import { renderDefensePanel, updateDefenseSelectionInfo } from '../ui/defensePanel.js';
 import { showStatus } from '../ui/status.js';
 
 function handleApiError(error, render) {
@@ -174,6 +175,25 @@ export function createGameActions(render) {
     }
   }
 
+  function handleDefenseReset() {
+    const data = stateCache.data;
+    const gameState = data?.game;
+    const teams = data?.teams || {};
+    const defenseKey = gameState?.defense;
+    const defenseTeam = defenseKey ? teams[defenseKey] : null;
+
+    stateCache.defensePlan = null;
+    resetDefenseSelection();
+
+    if (!defenseTeam) {
+      updateDefenseSelectionInfo();
+      return;
+    }
+
+    renderDefensePanel(defenseTeam, gameState);
+    updateDefenseSelectionInfo();
+  }
+
   async function handlePitcherChange() {
     if (!elements.pitcherSelect) return;
     const pitcherValue = elements.pitcherSelect.value;
@@ -218,6 +238,7 @@ export function createGameActions(render) {
     handleBunt,
     handlePinchHit,
     handleDefenseSubstitution,
+    handleDefenseReset,
     handlePitcherChange,
     loadInitialState,
   };

--- a/baseball_sim/ui/web/static/js/controllers/events.js
+++ b/baseball_sim/ui/web/static/js/controllers/events.js
@@ -47,6 +47,9 @@ export function initEventListeners(actions) {
       openModal('stats');
     });
   }
+  if (elements.defenseResetButton) {
+    elements.defenseResetButton.addEventListener('click', actions.handleDefenseReset);
+  }
   if (elements.defenseApplyButton) {
     elements.defenseApplyButton.addEventListener('click', actions.handleDefenseSubstitution);
   }

--- a/baseball_sim/ui/web/static/js/dom.js
+++ b/baseball_sim/ui/web/static/js/dom.js
@@ -44,6 +44,7 @@ export const elements = {
   pitcherModal: document.getElementById('pitcher-modal'),
   statsModal: document.getElementById('stats-modal'),
   modalCloseButtons: Array.from(document.querySelectorAll('.modal-close')),
+  defenseResetButton: document.getElementById('defense-reset-button'),
   defenseApplyButton: document.getElementById('defense-sub-button'),
   defenseField: document.getElementById('defense-field'),
   defenseBench: document.getElementById('defense-bench-panel'),

--- a/baseball_sim/ui/web/static/js/ui/defensePanel.js
+++ b/baseball_sim/ui/web/static/js/ui/defensePanel.js
@@ -622,6 +622,11 @@ export function updateDefenseSelectionInfo() {
     elements.defenseApplyButton.disabled = !canApply;
   }
 
+  const canReset = Boolean(plan) && operationsCount > 0;
+  if (elements.defenseResetButton) {
+    elements.defenseResetButton.disabled = !canReset;
+  }
+
   applyDefenseSelectionHighlights();
 }
 

--- a/baseball_sim/ui/web/templates/index.html
+++ b/baseball_sim/ui/web/templates/index.html
@@ -283,7 +283,8 @@
         <div class="modal-footer defense-footer">
           <p class="selection-info" id="defense-selection-info">守備交代を行う守備位置とベンチ選手を選択してください。</p>
           <div class="defense-actions">
-            <button id="defense-sub-button" class="primary">守備交代を適用</button>
+            <button type="button" id="defense-reset-button">リセット</button>
+            <button type="button" id="defense-sub-button" class="primary">守備交代を適用</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a reset control next to the defense substitution apply button in the web UI
- wire the reset button to rebuild the defense plan and clear pending swaps without closing the modal

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d26791472c832295ecd39f5e5af3e4