### PR TITLE
Support extra innings on the web scoreboard

### DIFF
--- a/baseball_sim/ui/web/static/css/game.css
+++ b/baseball_sim/ui/web/static/css/game.css
@@ -5,6 +5,10 @@
   gap: 24px;
 }
 
+.game-layout > .scoreboard {
+  grid-column: 1 / -1;
+}
+
 .field-column {
   display: flex;
   flex-direction: column;

--- a/baseball_sim/ui/web/static/js/ui/renderers.js
+++ b/baseball_sim/ui/web/static/js/ui/renderers.js
@@ -211,6 +211,11 @@ function updateScoreboard(gameState, teams) {
   );
   const hits = gameState.hits || { home: 0, away: 0 };
   const errors = gameState.errors || { home: 0, away: 0 };
+  const inningNumber = Number(gameState.inning);
+  const currentInningIndex = Number.isFinite(inningNumber) && inningNumber > 0 ? inningNumber - 1 : null;
+  const half = String(gameState.half || '').toLowerCase();
+  const isTopHalf = half === 'top';
+  const gameOver = Boolean(gameState.game_over);
 
   let html = '<table class="score-table"><thead><tr><th class="team-col">Team</th>';
   for (let i = 0; i < innings; i += 1) {
@@ -226,20 +231,15 @@ function updateScoreboard(gameState, teams) {
     const totalErrors = errors?.[teamKey] ?? 0;
     let row = `<tr><td class="team-name">${teamName}</td>`;
     const isHomeTeam = teamKey === 'home';
-    const isTopHalf = String(gameState.half || '').toLowerCase() === 'top';
-    const inningNumber = Number(gameState.inning);
-    const currentInningIndex = Number.isFinite(inningNumber) && inningNumber > 0 ? inningNumber - 1 : null;
     for (let i = 0; i < innings; i += 1) {
       const value = scores[i];
       let displayValue = value ?? '';
-      if (
-        isHomeTeam &&
-        isTopHalf &&
-        currentInningIndex !== null &&
-        i === currentInningIndex &&
-        (value === 0 || value === '0')
-      ) {
-        displayValue = '';
+      if (isHomeTeam && currentInningIndex !== null && i === currentInningIndex) {
+        if (gameOver && isTopHalf) {
+          displayValue = 'x';
+        } else if (isTopHalf && (value === 0 || value === '0' || value == null)) {
+          displayValue = '';
+        }
       }
       row += `<td>${displayValue}</td>`;
     }

--- a/baseball_sim/ui/web/templates/index.html
+++ b/baseball_sim/ui/web/templates/index.html
@@ -151,9 +151,9 @@
           </div>
 
           <div class="game-layout">
-            <div class="field-column">
-              <div class="scoreboard" id="scoreboard"></div>
+            <div class="scoreboard" id="scoreboard"></div>
 
+            <div class="field-column">
               <div class="situation-panel">
                 <div class="inning-chip" id="half-indicator"></div>
                 <div class="situation-text">


### PR DESCRIPTION
## Summary
- move the web scoreboard to span the full game layout width so extra innings columns fit without colliding with the control column
- show an "x" for the home team when the game ends before the bottom half is played
- leave the remainder of the field and control columns below the widened scoreboard for better spacing

## Testing
- pytest *(fails: missing joblib/torch)*

------
https://chatgpt.com/codex/tasks/task_e_68d299fab2508322a9e2dfb39e35eff0