### PR TITLE
Fix innings pitched accounting for web stats

### DIFF
--- a/baseball_sim/gameplay/game.py
+++ b/baseball_sim/gameplay/game.py
@@ -198,8 +198,16 @@ class GameState:
 
         return True, ""
 
-    def add_out(self):
-        """アウトカウントを増やし、必要に応じて攻守交代"""
+    def add_out(self, credit_pitcher: bool = True):
+        """アウトカウントを増やし、投手のIPも自動で更新する"""
+
+        if credit_pitcher:
+            pitching_stats = getattr(
+                getattr(self.fielding_team, "current_pitcher", None), "pitching_stats", None
+            )
+            if isinstance(pitching_stats, dict):
+                pitching_stats["IP"] = pitching_stats.get("IP", 0) + (1 / 3)
+
         inning_complete = self._half_state.register_out()
         if inning_complete:
             self.switch_sides()

--- a/baseball_sim/gameplay/outcomes/handler.py
+++ b/baseball_sim/gameplay/outcomes/handler.py
@@ -34,7 +34,6 @@ class AtBatOutcomeHandler:
 
     def _handle_strikeout(self, batter) -> str:
         pitcher = self._game_state.fielding_team.current_pitcher
-        pitcher.pitching_stats["IP"] += 1 / 3
         batter.stats["AB"] += 1
         StatsCalculator.record_strikeout(batter.stats)
         StatsCalculator.record_strikeout(pitcher.pitching_stats)
@@ -91,8 +90,6 @@ class AtBatOutcomeHandler:
         return f"{runs}-run home run!" if runs > 1 else "Solo home run!"
 
     def _handle_groundout(self, batter) -> str:
-        pitcher = self._game_state.fielding_team.current_pitcher
-        pitcher.pitching_stats["IP"] += 1 / 3
         batter.stats["AB"] += 1
         runs, message = self._runner_engine.apply_groundout(batter)
         if runs > 0:
@@ -100,8 +97,6 @@ class AtBatOutcomeHandler:
         return message
 
     def _apply_flyout_result(self, batter, runner_handler: Callable[[object], int], default_message: str) -> str:
-        pitcher = self._game_state.fielding_team.current_pitcher
-        pitcher.pitching_stats["IP"] += 1 / 3
         batter.stats["AB"] += 1
         runs = runner_handler(batter)
         self._game_state.add_out()

--- a/baseball_sim/gameplay/utils.py
+++ b/baseball_sim/gameplay/utils.py
@@ -164,8 +164,7 @@ class BuntProcessor:
         # 統計更新
         batter.stats["AB"] += 1
         batter.stats["SAC"] = batter.stats.get("SAC", 0) + 1
-        self.game_state.fielding_team.current_pitcher.pitching_stats["IP"] += 1/3
-        
+
         # 進塁前の塁状況を記録
         runners_before = [
             base is not None for base in self.game_state.bases
@@ -203,8 +202,7 @@ class BuntProcessor:
         """バントアウトの処理"""
         # 統計更新
         batter.stats["AB"] += 1
-        self.game_state.fielding_team.current_pitcher.pitching_stats["IP"] += 1/3
-        
+
         # バントアウト時のランナー処理
         runner_out_message = self._handle_bunt_out_scenarios()
         
@@ -220,7 +218,6 @@ class BuntProcessor:
         """バント失敗の処理"""
         # 統計更新
         batter.stats["AB"] += 1
-        self.game_state.fielding_team.current_pitcher.pitching_stats["IP"] += 1/3
         
         # バント失敗時の追加アウト判定
         additional_outs = self._handle_bunt_failure()
@@ -784,8 +781,6 @@ class RunnerEngine:
             clear_base(self.game_state.bases, 0)
             self.game_state.add_out()  # 一塁走者
             self.game_state.add_out()  # 打者
-            # 追加のアウト分のIPを加算
-            self.game_state.fielding_team.current_pitcher.pitching_stats["IP"] += 1/3
             if runs_scored > 0:
                 return runs_scored, f"Double play! {runs_scored} run(s) scored!"
             return 0, "Double play!"
@@ -801,7 +796,6 @@ class RunnerEngine:
             clear_base(self.game_state.bases, 0)
             self.game_state.add_out()  # 一塁走者 (2アウト目)
             self.game_state.add_out()  # 打者 (3アウト目)
-            self.game_state.fielding_team.current_pitcher.pitching_stats["IP"] += 1/3
             return 0, "Inning-ending double play!"
         else:
             return self._handle_force_out_only(batter, runner_situation)


### PR DESCRIPTION
## Summary
- credit the active pitcher for every recorded out directly in `GameState.add_out`
- stop manually adding fractional innings in at-bat and bunt handlers so all outs flow through the unified logic
- ensure double plays and other runner outs also update IP via the centralized out tracking

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'joblib'; ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68d2ac7753c48322ac23da5d482e8907