### PR TITLE
Move play result display into field column

### DIFF
--- a/baseball_sim/ui/web/static/css/game.css
+++ b/baseball_sim/ui/web/static/css/game.css
@@ -15,6 +15,27 @@
   gap: 20px;
 }
 
+.play-result-card {
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.play-result-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 15% 35%, rgba(148, 163, 184, 0.22), transparent 55%),
+    radial-gradient(circle at 85% 25%, rgba(56, 189, 248, 0.18), transparent 60%);
+  opacity: 0.35;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.play-result-card:empty::before {
+  opacity: 0;
+}
+
 .control-column {
   display: flex;
   flex-direction: column;

--- a/baseball_sim/ui/web/static/css/layout.css
+++ b/baseball_sim/ui/web/static/css/layout.css
@@ -21,37 +21,53 @@
 }
 
 .status-message {
-  min-height: 32px;
-  color: var(--accent-muted);
+  position: relative;
+  min-height: 64px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 18px 24px;
+  border-radius: 18px;
   font-weight: 600;
-  padding: 12px 18px;
-  border-radius: 12px;
-  background: rgba(8, 11, 24, 0.6);
-  border: 1px solid rgba(56, 189, 248, 0.25);
-  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.45);
+  letter-spacing: 0.03em;
+  line-height: 1.5;
+  color: var(--accent-muted);
+  background: linear-gradient(145deg, rgba(8, 11, 24, 0.78), rgba(8, 11, 24, 0.58));
+  border: 1px solid rgba(56, 189, 248, 0.22);
+  box-shadow: 0 22px 44px rgba(2, 6, 23, 0.48);
   transition: all 0.3s ease;
 }
 
+.status-message:empty {
+  display: none;
+}
+
 .status-message.danger {
-  color: var(--danger);
+  color: #fecaca;
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.22), rgba(67, 13, 13, 0.6));
+  border-color: rgba(248, 113, 113, 0.45);
+  box-shadow: 0 24px 52px rgba(248, 113, 113, 0.28);
 }
 
 .status-message.success {
-  color: var(--success);
-  background: rgba(52, 211, 153, 0.12);
-  border-color: rgba(52, 211, 153, 0.35);
-  box-shadow: 0 18px 42px rgba(16, 185, 129, 0.25);
+  color: #d1fae5;
+  background: linear-gradient(135deg, rgba(52, 211, 153, 0.22), rgba(6, 78, 59, 0.55));
+  border-color: rgba(52, 211, 153, 0.45);
+  box-shadow: 0 24px 52px rgba(16, 185, 129, 0.28);
 }
 
 .status-message.info {
-  color: var(--accent);
+  color: #e0f2fe;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.26), rgba(8, 47, 73, 0.55));
+  border-color: rgba(56, 189, 248, 0.45);
+  box-shadow: 0 24px 52px rgba(56, 189, 248, 0.26);
 }
 
 .status-message.warning {
-  color: var(--warning);
-  background: rgba(250, 204, 21, 0.12);
-  border-color: rgba(250, 204, 21, 0.32);
-  box-shadow: 0 16px 32px rgba(250, 204, 21, 0.18);
+  color: #fef3c7;
+  background: linear-gradient(135deg, rgba(250, 204, 21, 0.22), rgba(113, 63, 18, 0.55));
+  border-color: rgba(250, 204, 21, 0.4);
+  box-shadow: 0 24px 48px rgba(250, 204, 21, 0.28);
 }
 
 .screen.hidden {

--- a/baseball_sim/ui/web/static/js/ui/status.js
+++ b/baseball_sim/ui/web/static/js/ui/status.js
@@ -3,16 +3,22 @@ import { elements } from '../dom.js';
 export function setStatusMessage(notification) {
   if (!notification) {
     elements.statusMessage.textContent = '';
-    elements.statusMessage.classList.remove('danger', 'success', 'info');
+    elements.statusMessage.classList.remove('danger', 'success', 'info', 'warning');
+    elements.statusMessage.removeAttribute('data-level');
     return;
   }
-  elements.statusMessage.textContent = notification.message;
-  elements.statusMessage.classList.remove('danger', 'success', 'info');
-  elements.statusMessage.classList.add(notification.level || 'info');
+  const level = notification.level || 'info';
+  const message = notification.message ?? '';
+  elements.statusMessage.textContent = message;
+  elements.statusMessage.classList.remove('danger', 'success', 'info', 'warning');
+  elements.statusMessage.classList.add(level);
+  elements.statusMessage.dataset.level = level;
 }
 
 export function showStatus(message, level = 'danger') {
-  elements.statusMessage.textContent = message;
-  elements.statusMessage.classList.remove('danger', 'success', 'info');
+  const resolvedMessage = message ?? '';
+  elements.statusMessage.textContent = resolvedMessage;
+  elements.statusMessage.classList.remove('danger', 'success', 'info', 'warning');
   elements.statusMessage.classList.add(level);
+  elements.statusMessage.dataset.level = level;
 }

--- a/baseball_sim/ui/web/templates/index.html
+++ b/baseball_sim/ui/web/templates/index.html
@@ -112,7 +112,6 @@
       </header>
 
       <main class="app-main">
-        <div id="status-message" class="status-message" role="status"></div>
 
         <section id="title-screen" class="screen">
           <div class="title-card">
@@ -162,6 +161,8 @@
                 </div>
                 <div class="outs-chip" id="outs-indicator"></div>
               </div>
+
+              <div class="play-result-card status-message" id="status-message" role="status" aria-live="polite"></div>
 
               <div class="bases" id="base-state">
                 <div class="field-layer field-outfield" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- reposition the status message element into the field column between the situation panel and base graphic
- refresh play result styling with a dedicated card treatment and vivid color themes for each outcome level
- update status handling logic to support warning resets and data attributes for the relocated display

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2b9ebb7a08322b9eb4f756c775389