### PR TITLE
Revamp web UI styling and typography

### DIFF
--- a/baseball_sim/ui/web/static/css/base.css
+++ b/baseball_sim/ui/web/static/css/base.css
@@ -1,21 +1,31 @@
 :root {
-  --bg: #020617;
-  --surface: rgba(12, 20, 40, 0.92);
-  --surface-strong: rgba(4, 10, 24, 0.96);
-  --surface-soft: rgba(15, 23, 42, 0.75);
-  --accent: #22d3ee;
-  --accent-muted: #38bdf8;
-  --highlight: #a855f7;
+  --bg: #050414;
+  --bg-alt: #070c21;
+  --surface: rgba(14, 20, 36, 0.86);
+  --surface-strong: rgba(7, 12, 27, 0.94);
+  --surface-soft: rgba(19, 32, 62, 0.72);
+  --surface-glow: rgba(56, 189, 248, 0.1);
+  --accent: #60a5fa;
+  --accent-strong: #38bdf8;
+  --accent-muted: #7dd3fc;
+  --highlight: #c084fc;
   --text: #f8fafc;
-  --text-muted: rgba(191, 219, 254, 0.75);
+  --text-strong: #ffffff;
+  --text-muted: rgba(203, 213, 225, 0.75);
   --danger: #f87171;
   --success: #34d399;
   --warning: #facc15;
-  --border: rgba(56, 189, 248, 0.18);
-  --grid-line: rgba(56, 189, 248, 0.12);
-  --glow: rgba(56, 189, 248, 0.32);
-  --glow-strong: rgba(168, 85, 247, 0.32);
-  --font-body: 'Noto Sans JP', 'Segoe UI', 'Roboto', sans-serif;
+  --border: rgba(125, 211, 252, 0.2);
+  --border-strong: rgba(125, 211, 252, 0.34);
+  --grid-line: rgba(79, 70, 229, 0.12);
+  --glow: rgba(125, 211, 252, 0.24);
+  --glow-strong: rgba(192, 132, 252, 0.3);
+  --accent-gradient: linear-gradient(135deg, rgba(125, 211, 252, 0.92), rgba(192, 132, 252, 0.92));
+  --accent-gradient-soft: linear-gradient(135deg, rgba(96, 165, 250, 0.2), rgba(192, 132, 252, 0.12));
+  --glass-gradient: linear-gradient(145deg, rgba(7, 12, 27, 0.9), rgba(26, 35, 68, 0.66));
+  --font-body: 'Figtree', 'Zen Kaku Gothic New', 'Noto Sans JP', 'Segoe UI', sans-serif;
+  --font-heading: 'Zen Kaku Gothic New', 'Noto Sans JP', 'Segoe UI', sans-serif;
+  --font-mono: 'IBM Plex Mono', 'Roboto Mono', monospace;
 }
 
 * {
@@ -26,15 +36,19 @@ body {
   margin: 0;
   font-family: var(--font-body);
   background:
-    radial-gradient(circle at 18% 24%, rgba(56, 189, 248, 0.2), transparent 45%),
-    radial-gradient(circle at 82% 12%, rgba(168, 85, 247, 0.18), transparent 58%),
-    radial-gradient(circle at 50% 120%, rgba(15, 118, 110, 0.15), transparent 65%),
-    #020617;
+    radial-gradient(circle at 8% 12%, rgba(96, 165, 250, 0.25), transparent 40%),
+    radial-gradient(circle at 92% 14%, rgba(192, 132, 252, 0.22), transparent 52%),
+    radial-gradient(circle at 50% 120%, rgba(45, 212, 191, 0.18), transparent 65%),
+    var(--bg);
   background-attachment: fixed;
   color: var(--text);
   min-height: 100vh;
   position: relative;
   overflow-x: hidden;
+  font-size: 15px;
+  line-height: 1.65;
+  letter-spacing: 0.01em;
+  color-scheme: dark;
 }
 
 body::before {
@@ -42,10 +56,10 @@ body::before {
   position: fixed;
   inset: 0;
   background:
-    linear-gradient(90deg, transparent 0%, var(--grid-line) 49%, transparent 51%),
-    linear-gradient(0deg, transparent 0%, var(--grid-line) 49%, transparent 51%);
-  background-size: 120px 120px;
-  opacity: 0.35;
+    linear-gradient(90deg, transparent 0%, var(--grid-line) 48%, transparent 52%),
+    linear-gradient(0deg, transparent 0%, var(--grid-line) 48%, transparent 52%);
+  background-size: 140px 140px;
+  opacity: 0.28;
   pointer-events: none;
   z-index: 0;
 }
@@ -54,10 +68,40 @@ body::after {
   content: '';
   position: fixed;
   inset: -20% -30%;
-  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.12), transparent 55%);
-  filter: blur(60px);
+  background: radial-gradient(circle at center, rgba(129, 140, 248, 0.18), transparent 55%);
+  filter: blur(70px);
   pointer-events: none;
   z-index: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+p {
+  margin: 0;
+}
+
+p + p {
+  margin-top: 0.75em;
+}
+
+a {
+  color: var(--accent-muted);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--highlight);
 }
 
 .hidden {
@@ -86,20 +130,22 @@ body::after {
 
 .app-header {
   position: relative;
-  padding: 32px clamp(20px, 6vw, 48px) 28px;
-  border-bottom: 1px solid var(--border);
+  padding: 36px clamp(24px, 6vw, 60px) 32px;
+  border-bottom: 1px solid var(--border-strong);
   overflow: hidden;
-  background: linear-gradient(145deg, rgba(34, 211, 238, 0.08), rgba(15, 23, 42, 0.85));
+  background: var(--glass-gradient);
+  box-shadow: 0 36px 90px rgba(5, 12, 32, 0.6);
+  backdrop-filter: blur(18px);
 }
 
 .header-overlay {
   position: absolute;
-  inset: -40% -20%;
+  inset: -45% -25%;
   background:
-    radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.25), transparent 55%),
-    radial-gradient(circle at 80% 10%, rgba(168, 85, 247, 0.22), transparent 60%),
-    radial-gradient(circle at 60% 80%, rgba(14, 165, 233, 0.18), transparent 65%);
-  filter: blur(40px);
+    radial-gradient(circle at 20% 30%, rgba(96, 165, 250, 0.35), transparent 55%),
+    radial-gradient(circle at 82% 18%, rgba(192, 132, 252, 0.32), transparent 60%),
+    radial-gradient(circle at 62% 82%, rgba(45, 212, 191, 0.24), transparent 65%);
+  filter: blur(48px);
   opacity: 0.9;
   pointer-events: none;
   z-index: 0;
@@ -110,7 +156,7 @@ body::after {
   z-index: 1;
   display: flex;
   flex-direction: column;
-  gap: 28px;
+  gap: 32px;
   max-width: 1200px;
   margin: 0 auto;
   width: 100%;
@@ -133,17 +179,23 @@ body::after {
 
 .title-group h1 {
   margin: 0;
-  font-size: clamp(32px, 5vw, 48px);
-  letter-spacing: 0.08em;
+  font-size: clamp(36px, 5.6vw, 60px);
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  text-shadow: 0 6px 16px rgba(8, 47, 73, 0.45);
+  background: linear-gradient(120deg, var(--accent-strong), var(--highlight));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  text-shadow: 0 12px 26px rgba(5, 10, 25, 0.4);
 }
 
 .subtitle {
-  margin: 12px 0 0;
+  margin: 14px 0 0;
   color: var(--text-muted);
-  max-width: 640px;
-  font-size: 15px;
+  max-width: 620px;
+  font-size: 16px;
+  font-weight: 500;
   letter-spacing: 0.04em;
 }
 
@@ -159,25 +211,26 @@ body::after {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 14px;
+  padding: 6px 16px;
   border-radius: 999px;
-  background: rgba(56, 189, 248, 0.12);
-  border: 1px solid rgba(56, 189, 248, 0.35);
-  color: var(--accent-muted);
+  background: var(--accent-gradient-soft);
+  border: 1px solid var(--border-strong);
+  color: var(--accent);
   font-size: 11px;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
   box-shadow:
-    0 10px 24px rgba(8, 47, 73, 0.35),
-    inset 0 0 12px rgba(56, 189, 248, 0.15);
+    0 12px 26px rgba(8, 17, 40, 0.4),
+    inset 0 0 0 1px rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(6px);
 }
 
 .header-insights {
   position: relative;
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 18px;
-  padding: 4px;
+  gap: 20px;
+  padding: 6px;
 }
 
 .header-insights::before {
@@ -185,12 +238,12 @@ body::after {
   position: absolute;
   inset: -16px -20px;
   background:
-    radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.12), transparent 60%),
-    linear-gradient(135deg, rgba(148, 163, 184, 0.08), transparent 55%);
-  border-radius: 28px;
-  border: 1px solid rgba(56, 189, 248, 0.18);
-  opacity: 0.7;
-  filter: blur(0.4px);
+    radial-gradient(circle at 20% 25%, rgba(96, 165, 250, 0.18), transparent 60%),
+    linear-gradient(135deg, rgba(192, 132, 252, 0.14), transparent 55%);
+  border-radius: 30px;
+  border: 1px solid rgba(125, 211, 252, 0.25);
+  opacity: 0.75;
+  filter: blur(0.2px);
   pointer-events: none;
   z-index: 0;
 }
@@ -202,34 +255,34 @@ body::after {
 
 .insight-card {
   position: relative;
-  padding: 18px 20px;
-  border-radius: 18px;
-  border: 1px solid rgba(56, 189, 248, 0.25);
-  background: linear-gradient(140deg, rgba(8, 11, 24, 0.75), rgba(8, 47, 73, 0.18));
-  box-shadow: 0 18px 40px rgba(2, 6, 23, 0.35);
+  padding: 20px 22px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: linear-gradient(150deg, rgba(7, 12, 28, 0.92), rgba(32, 46, 84, 0.54));
+  box-shadow: 0 28px 56px rgba(5, 12, 30, 0.55);
   overflow: hidden;
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(12px);
 }
 
 .insight-card::before {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at top right, rgba(168, 85, 247, 0.28), transparent 55%);
-  opacity: 0.8;
+  background: radial-gradient(circle at 82% 12%, rgba(192, 132, 252, 0.32), transparent 60%);
+  opacity: 0.85;
   pointer-events: none;
 }
 
 .insight-card::after {
   content: '';
   position: absolute;
-  top: -120%;
-  left: -60%;
+  top: -110%;
+  left: -55%;
   width: 220%;
   height: 220%;
-  background: linear-gradient(130deg, transparent 40%, rgba(56, 189, 248, 0.15) 50%, transparent 60%);
+  background: linear-gradient(130deg, transparent 40%, rgba(125, 211, 252, 0.16) 50%, transparent 62%);
   transform: rotate(8deg);
-  animation: insight-glimmer 8s ease-in-out infinite;
+  animation: insight-glimmer 9s ease-in-out infinite;
   pointer-events: none;
 }
 
@@ -255,8 +308,8 @@ body::after {
   justify-content: space-between;
   gap: 12px;
   margin-bottom: 12px;
-  font-size: 12px;
-  letter-spacing: 0.18em;
+  font-size: 11px;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
   color: var(--text-muted);
 }
@@ -268,11 +321,15 @@ body::after {
 
 .insight-value {
   position: relative;
-  font-size: clamp(28px, 4vw, 40px);
-  font-weight: 700;
+  font-size: clamp(30px, 4.2vw, 42px);
+  font-weight: 800;
   margin: 0;
-  color: var(--accent-muted);
-  text-shadow: 0 10px 24px rgba(8, 47, 73, 0.65);
+  font-family: var(--font-heading);
+  color: var(--text-strong);
+  letter-spacing: 0.04em;
+  text-shadow:
+    0 14px 30px rgba(8, 17, 40, 0.65),
+    0 0 24px rgba(125, 211, 252, 0.25);
 }
 
 .insight-value[data-trend='positive'] {
@@ -296,17 +353,17 @@ body::after {
 }
 
 .insight-caption {
-  margin: 6px 0 0;
+  margin: 8px 0 0;
   font-size: 13px;
   color: var(--text-muted);
-  letter-spacing: 0.04em;
+  letter-spacing: 0.05em;
 }
 
 .insight-meta {
   margin: 10px 0 0;
   font-size: 12px;
-  letter-spacing: 0.08em;
-  color: rgba(148, 163, 184, 0.75);
+  letter-spacing: 0.1em;
+  color: rgba(191, 219, 254, 0.66);
 }
 
 .insight-trace {
@@ -318,9 +375,11 @@ body::after {
   height: 52px;
   padding: 10px 12px;
   border-radius: 14px;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.7), rgba(2, 6, 23, 0.92));
-  border: 1px solid rgba(56, 189, 248, 0.18);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.08);
+  background: linear-gradient(180deg, rgba(9, 14, 28, 0.85), rgba(4, 7, 16, 0.95));
+  border: 1px solid rgba(125, 211, 252, 0.18);
+  box-shadow:
+    inset 0 0 0 1px rgba(148, 163, 184, 0.1),
+    0 8px 18px rgba(5, 10, 23, 0.45);
   overflow: hidden;
 }
 
@@ -352,14 +411,14 @@ body::after {
   flex: 1;
   height: var(--h, 50%);
   border-radius: 8px 8px 2px 2px;
-  background: linear-gradient(180deg, var(--accent) 0%, rgba(34, 211, 238, 0.35) 65%, rgba(3, 7, 18, 0.3) 100%);
+  background: linear-gradient(180deg, rgba(125, 211, 252, 0.95) 0%, rgba(56, 189, 248, 0.45) 65%, rgba(3, 7, 18, 0.35) 100%);
   box-shadow:
-    0 0 12px rgba(56, 189, 248, 0.32),
-    0 10px 18px rgba(2, 6, 23, 0.4);
+    0 0 12px rgba(125, 211, 252, 0.32),
+    0 12px 22px rgba(5, 12, 30, 0.4);
   transform-origin: bottom center;
   animation: insight-trace-pulse 6.4s ease-in-out infinite;
   animation-delay: calc(var(--i, 0) * -0.35s);
-  opacity: 0.85;
+  opacity: 0.88;
 }
 
 .insight-trace span::after {
@@ -367,9 +426,9 @@ body::after {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(180deg, rgba(248, 250, 252, 0.4), transparent 55%);
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.5), transparent 60%);
   mix-blend-mode: screen;
-  opacity: 0.5;
+  opacity: 0.55;
 }
 
 @keyframes insight-trace-pulse {
@@ -443,7 +502,7 @@ body::after {
   border: 1px solid rgba(56, 189, 248, 0.45);
   border-radius: 6px;
   padding: 2px 6px;
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-size: 0.9em;
   color: var(--accent-muted);
   box-shadow: 0 1px 10px rgba(2, 6, 23, 0.45);

--- a/baseball_sim/ui/web/static/css/game.css
+++ b/baseball_sim/ui/web/static/css/game.css
@@ -25,9 +25,9 @@
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(circle at 15% 35%, rgba(148, 163, 184, 0.22), transparent 55%),
-    radial-gradient(circle at 85% 25%, rgba(56, 189, 248, 0.18), transparent 60%);
-  opacity: 0.35;
+    radial-gradient(circle at 18% 38%, rgba(96, 165, 250, 0.26), transparent 55%),
+    radial-gradient(circle at 86% 28%, rgba(192, 132, 252, 0.2), transparent 60%);
+  opacity: 0.4;
   pointer-events: none;
   transition: opacity 0.3s ease;
 }
@@ -44,14 +44,14 @@
 
 .scoreboard {
   position: relative;
-  background: linear-gradient(160deg, rgba(4, 10, 24, 0.94), rgba(8, 47, 73, 0.6));
-  border-radius: 22px;
-  padding: 20px;
-  border: 1px solid rgba(56, 189, 248, 0.25);
+  background: linear-gradient(160deg, rgba(7, 12, 28, 0.94), rgba(32, 46, 84, 0.58));
+  border-radius: 24px;
+  padding: 22px;
+  border: 1px solid var(--border);
   overflow: hidden;
   overflow-x: auto;
-  box-shadow: 0 28px 60px rgba(2, 6, 23, 0.55);
-  backdrop-filter: blur(6px);
+  box-shadow: 0 36px 72px rgba(5, 12, 32, 0.55);
+  backdrop-filter: blur(10px);
 }
 
 .scoreboard::before {
@@ -59,16 +59,16 @@
   position: absolute;
   inset: 0;
   background:
-    linear-gradient(90deg, rgba(56, 189, 248, 0.14), transparent 60%),
-    linear-gradient(0deg, rgba(168, 85, 247, 0.08), transparent 70%);
-  opacity: 0.45;
+    linear-gradient(90deg, rgba(96, 165, 250, 0.16), transparent 60%),
+    linear-gradient(0deg, rgba(192, 132, 252, 0.12), transparent 70%);
+  opacity: 0.5;
   pointer-events: none;
 }
 
 .scoreboard p {
   margin: 0;
   color: var(--text-muted);
-  letter-spacing: 0.05em;
+  letter-spacing: 0.06em;
 }
 
 .score-table {
@@ -83,12 +83,13 @@
 .score-table thead th {
   padding: 10px 12px;
   text-align: center;
-  font-size: 12px;
-  letter-spacing: 0.16em;
+  font-size: 11px;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: rgba(191, 219, 254, 0.88);
-  background: rgba(56, 189, 248, 0.16);
-  border-bottom: 1px solid rgba(56, 189, 248, 0.32);
+  color: rgba(191, 219, 254, 0.85);
+  background: rgba(96, 165, 250, 0.16);
+  border-bottom: 1px solid rgba(125, 211, 252, 0.28);
+  font-family: var(--font-heading);
 }
 
 .score-table thead th.team-col {
@@ -96,7 +97,7 @@
 }
 
 .score-table tbody tr {
-  border-bottom: 1px solid rgba(56, 189, 248, 0.12);
+  border-bottom: 1px solid rgba(125, 211, 252, 0.1);
   transition: transform 0.2s ease, background 0.2s ease;
 }
 
@@ -105,19 +106,24 @@
 }
 
 .score-table tbody tr:hover {
-  background: rgba(56, 189, 248, 0.08);
+  background: rgba(96, 165, 250, 0.1);
   transform: translateY(-2px);
 }
 
 .score-table td {
   padding: 10px 12px;
   text-align: center;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  letter-spacing: 0.04em;
 }
 
 .score-table td.team-name {
   text-align: left;
   font-weight: 600;
-  color: var(--accent-muted);
+  color: var(--accent);
+  font-family: var(--font-heading);
+  letter-spacing: 0.08em;
 }
 
 .score-table td:nth-last-child(-n + 3) {
@@ -128,12 +134,12 @@
   display: flex;
   align-items: center;
   gap: 16px;
-  background: var(--surface-soft);
-  border: 1px solid rgba(56, 189, 248, 0.2);
-  border-radius: 18px;
-  padding: 18px 22px;
-  box-shadow: 0 22px 48px rgba(2, 6, 23, 0.45);
-  backdrop-filter: blur(6px);
+  background: linear-gradient(150deg, rgba(7, 12, 26, 0.85), rgba(30, 41, 83, 0.55));
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 20px 24px;
+  box-shadow: 0 26px 56px rgba(5, 12, 30, 0.5);
+  backdrop-filter: blur(10px);
 }
 
 .inning-chip,
@@ -143,9 +149,10 @@
   padding: 12px 14px;
   border-radius: 14px;
   font-weight: 700;
-  background: rgba(56, 189, 248, 0.16);
-  color: var(--accent-muted);
-  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.32);
+  background: rgba(96, 165, 250, 0.18);
+  color: var(--accent);
+  box-shadow: inset 0 0 0 1px rgba(125, 211, 252, 0.32);
+  letter-spacing: 0.12em;
 }
 
 .outs-chip {
@@ -165,21 +172,24 @@
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  border: 2px solid rgba(248, 113, 113, 0.5);
-  background: rgba(248, 250, 252, 0.2);
-  box-shadow: inset 0 2px 4px rgba(15, 23, 42, 0.45);
+  border: 2px solid rgba(248, 113, 113, 0.55);
+  background: rgba(248, 250, 252, 0.22);
+  box-shadow: inset 0 2px 4px rgba(15, 23, 42, 0.5);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .out-dot.active {
   background: var(--danger);
   border-color: rgba(248, 113, 113, 0.95);
   box-shadow: 0 0 12px rgba(248, 113, 113, 0.45);
+  transform: scale(1.05);
 }
 
 .outs-label {
   letter-spacing: 0.12em;
   font-size: 13px;
-  color: var(--danger);
+  color: rgba(248, 113, 113, 0.85);
+  font-family: var(--font-heading);
 }
 
 .situation-text {
@@ -188,10 +198,12 @@
 
 .situation-text p {
   margin: 4px 0;
+  font-size: 15px;
 }
 
 .matchup {
-  color: var(--text-muted);
+  color: rgba(203, 213, 225, 0.75);
+  letter-spacing: 0.04em;
 }
 
 .bases {
@@ -199,9 +211,9 @@
   width: 280px;
   height: 280px;
   margin: clamp(32px, 8vh, 64px) auto 0;
-  background: radial-gradient(circle at 50% 92%, rgba(15, 23, 42, 0.28), rgba(2, 6, 23, 0.92));
-  border-radius: 28px;
-  box-shadow: 0 36px 72px rgba(8, 47, 73, 0.55);
+  background: radial-gradient(circle at 50% 92%, rgba(15, 23, 42, 0.32), rgba(3, 7, 18, 0.95));
+  border-radius: 30px;
+  box-shadow: 0 40px 80px rgba(5, 12, 32, 0.6);
   overflow: visible;
   isolation: isolate;
 }
@@ -398,10 +410,12 @@
 }
 
 .roster {
-  background: rgba(15, 23, 42, 0.75);
+  background: linear-gradient(150deg, rgba(7, 12, 24, 0.88), rgba(26, 39, 72, 0.54));
   border: 1px solid var(--border);
-  border-radius: 16px;
-  padding: 12px 16px;
+  border-radius: 18px;
+  padding: 14px 18px;
+  box-shadow: 0 24px 56px rgba(5, 12, 30, 0.45);
+  backdrop-filter: blur(8px);
 }
 
 .roster table {
@@ -435,7 +449,7 @@
 }
 
 .roster tbody tr.active {
-  background: rgba(96, 165, 250, 0.12);
+  background: rgba(96, 165, 250, 0.16);
 }
 
 .pitchers-panel {
@@ -445,12 +459,12 @@
 }
 
 .pitcher-list {
-  background: var(--surface-soft);
-  border: 1px solid rgba(56, 189, 248, 0.18);
-  border-radius: 18px;
-  padding: 18px;
-  box-shadow: 0 22px 48px rgba(2, 6, 23, 0.5);
-  backdrop-filter: blur(4px);
+  background: linear-gradient(150deg, rgba(7, 12, 24, 0.9), rgba(30, 41, 83, 0.58));
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 20px;
+  box-shadow: 0 26px 60px rgba(5, 12, 30, 0.5);
+  backdrop-filter: blur(10px);
 }
 
 .pitcher-list ul {
@@ -463,29 +477,29 @@
 }
 
 .pitcher-list li {
-  padding: 8px 10px;
+  padding: 9px 12px;
   border-radius: 12px;
-  background: rgba(15, 23, 42, 0.7);
+  background: rgba(15, 23, 42, 0.72);
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
 
 .pitcher-list li.current {
-  border: 1px solid rgba(56, 189, 248, 0.55);
-  background: rgba(56, 189, 248, 0.18);
+  border: 1px solid rgba(125, 211, 252, 0.5);
+  background: rgba(96, 165, 250, 0.18);
 }
 
 .controls-card {
-  background: var(--surface-soft);
-  border-radius: 20px;
-  border: 1px solid rgba(56, 189, 248, 0.2);
-  padding: 24px;
+  background: linear-gradient(150deg, rgba(7, 12, 26, 0.9), rgba(26, 39, 72, 0.58));
+  border-radius: 22px;
+  border: 1px solid var(--border);
+  padding: 26px;
   display: flex;
   flex-direction: column;
   gap: 12px;
-  box-shadow: 0 28px 60px rgba(2, 6, 23, 0.5);
-  backdrop-filter: blur(6px);
+  box-shadow: 0 32px 70px rgba(5, 12, 32, 0.55);
+  backdrop-filter: blur(12px);
 }
 
 .main-controls {
@@ -500,10 +514,10 @@
 
 .strategy-menu {
   margin-top: 12px;
-  padding: 16px 18px;
-  background: rgba(8, 11, 24, 0.78);
-  border: 1px solid rgba(56, 189, 248, 0.2);
-  border-radius: 16px;
+  padding: 18px 20px;
+  background: rgba(8, 13, 28, 0.82);
+  border: 1px solid rgba(125, 211, 252, 0.2);
+  border-radius: 18px;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -534,17 +548,24 @@
 .controls-card select {
   width: 100%;
   border-radius: 12px;
-  border: 1px solid rgba(56, 189, 248, 0.25);
-  padding: 10px 12px;
-  background: rgba(8, 11, 24, 0.85);
+  border: 1px solid rgba(125, 211, 252, 0.28);
+  padding: 12px 14px;
+  background: rgba(7, 12, 24, 0.85);
   color: var(--text);
   font-size: 14px;
   appearance: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .controls-card select:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.controls-card select:focus-visible {
+  outline: none;
+  border-color: rgba(125, 211, 252, 0.55);
+  box-shadow: 0 0 0 3px rgba(125, 211, 252, 0.2);
 }
 
 .strategy-card button {
@@ -563,14 +584,14 @@
 
 .log-panel {
   flex: 1;
-  background: var(--surface-soft);
-  border-radius: 20px;
-  border: 1px solid rgba(56, 189, 248, 0.2);
-  padding: 20px;
+  background: linear-gradient(150deg, rgba(7, 12, 26, 0.92), rgba(26, 39, 72, 0.6));
+  border-radius: 22px;
+  border: 1px solid var(--border);
+  padding: 22px;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 28px 60px rgba(2, 6, 23, 0.5);
-  backdrop-filter: blur(6px);
+  box-shadow: 0 32px 70px rgba(5, 12, 32, 0.55);
+  backdrop-filter: blur(12px);
 }
 
 .log-panel h3 small {
@@ -591,10 +612,12 @@
 .log-entry {
   padding: 12px 14px;
   border-radius: 14px;
-  background: rgba(8, 11, 24, 0.78);
+  background: rgba(8, 13, 28, 0.82);
   border-left: 4px solid transparent;
-  line-height: 1.5;
-  box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.08);
+  line-height: 1.55;
+  box-shadow:
+    inset 0 0 0 1px rgba(125, 211, 252, 0.08),
+    0 12px 24px rgba(5, 12, 30, 0.25);
 }
 
 .log-entry.info {
@@ -673,12 +696,12 @@
 }
 
 .app-footer {
-  padding: 20px 32px;
+  padding: 24px 32px;
   text-align: center;
-  color: var(--text-muted);
-  border-top: 1px solid rgba(56, 189, 248, 0.2);
-  background: rgba(4, 10, 24, 0.85);
-  letter-spacing: 0.08em;
+  color: rgba(203, 213, 225, 0.75);
+  border-top: 1px solid rgba(125, 211, 252, 0.2);
+  background: linear-gradient(160deg, rgba(5, 10, 23, 0.92), rgba(19, 32, 62, 0.58));
+  letter-spacing: 0.1em;
   font-size: 12px;
 }
 

--- a/baseball_sim/ui/web/static/css/layout.css
+++ b/baseball_sim/ui/web/static/css/layout.css
@@ -1,9 +1,9 @@
 .app-main {
   flex: 1;
-  padding: 32px clamp(20px, 6vw, 56px) 72px;
+  padding: 40px clamp(24px, 6vw, 64px) 80px;
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 36px;
   position: relative;
   max-width: 1320px;
   margin: 0 auto;
@@ -13,9 +13,9 @@
 .app-main::before {
   content: '';
   position: absolute;
-  inset: 40px 10% -60px;
-  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.12), transparent 65%);
-  filter: blur(80px);
+  inset: 48px 8% -80px;
+  background: radial-gradient(circle at top, rgba(125, 211, 252, 0.16), transparent 65%);
+  filter: blur(90px);
   z-index: -1;
   pointer-events: none;
 }
@@ -26,16 +26,17 @@
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 18px 24px;
-  border-radius: 18px;
+  padding: 20px 26px;
+  border-radius: 20px;
   font-weight: 600;
-  letter-spacing: 0.03em;
-  line-height: 1.5;
+  letter-spacing: 0.04em;
+  line-height: 1.55;
   color: var(--accent-muted);
-  background: linear-gradient(145deg, rgba(8, 11, 24, 0.78), rgba(8, 11, 24, 0.58));
-  border: 1px solid rgba(56, 189, 248, 0.22);
-  box-shadow: 0 22px 44px rgba(2, 6, 23, 0.48);
+  background: linear-gradient(150deg, rgba(5, 10, 24, 0.88), rgba(19, 32, 62, 0.55));
+  border: 1px solid var(--border);
+  box-shadow: 0 28px 56px rgba(5, 12, 30, 0.55);
   transition: all 0.3s ease;
+  backdrop-filter: blur(10px);
 }
 
 .status-message:empty {
@@ -46,28 +47,28 @@
   color: #fecaca;
   background: linear-gradient(135deg, rgba(248, 113, 113, 0.22), rgba(67, 13, 13, 0.6));
   border-color: rgba(248, 113, 113, 0.45);
-  box-shadow: 0 24px 52px rgba(248, 113, 113, 0.28);
+  box-shadow: 0 28px 60px rgba(248, 113, 113, 0.28);
 }
 
 .status-message.success {
   color: #d1fae5;
   background: linear-gradient(135deg, rgba(52, 211, 153, 0.22), rgba(6, 78, 59, 0.55));
   border-color: rgba(52, 211, 153, 0.45);
-  box-shadow: 0 24px 52px rgba(16, 185, 129, 0.28);
+  box-shadow: 0 28px 60px rgba(16, 185, 129, 0.28);
 }
 
 .status-message.info {
   color: #e0f2fe;
   background: linear-gradient(135deg, rgba(56, 189, 248, 0.26), rgba(8, 47, 73, 0.55));
   border-color: rgba(56, 189, 248, 0.45);
-  box-shadow: 0 24px 52px rgba(56, 189, 248, 0.26);
+  box-shadow: 0 28px 60px rgba(56, 189, 248, 0.28);
 }
 
 .status-message.warning {
   color: #fef3c7;
   background: linear-gradient(135deg, rgba(250, 204, 21, 0.22), rgba(113, 63, 18, 0.55));
   border-color: rgba(250, 204, 21, 0.4);
-  box-shadow: 0 24px 48px rgba(250, 204, 21, 0.28);
+  box-shadow: 0 28px 56px rgba(250, 204, 21, 0.28);
 }
 
 .screen.hidden {
@@ -76,13 +77,13 @@
 
 .title-card {
   position: relative;
-  background: linear-gradient(150deg, rgba(4, 10, 24, 0.92), rgba(8, 47, 73, 0.45));
-  border: 1px solid rgba(56, 189, 248, 0.25);
-  border-radius: 24px;
-  padding: 32px clamp(20px, 5vw, 48px);
+  background: linear-gradient(150deg, rgba(7, 12, 28, 0.92), rgba(30, 41, 83, 0.54));
+  border: 1px solid var(--border-strong);
+  border-radius: 26px;
+  padding: 36px clamp(24px, 5vw, 52px);
   box-shadow:
-    0 36px 80px rgba(2, 6, 23, 0.6),
-    inset 0 0 0 1px rgba(148, 163, 184, 0.08);
+    0 40px 90px rgba(5, 12, 32, 0.58),
+    inset 0 0 0 1px rgba(148, 163, 184, 0.1);
   max-width: 980px;
   margin: 0 auto;
   overflow: hidden;
@@ -93,15 +94,15 @@
   position: absolute;
   inset: 0;
   background:
-    linear-gradient(125deg, rgba(56, 189, 248, 0.12), transparent 60%),
+    linear-gradient(125deg, rgba(96, 165, 250, 0.14), transparent 60%),
     repeating-linear-gradient(
       0deg,
       transparent,
       transparent 14px,
-      rgba(56, 189, 248, 0.08) 14px,
-      rgba(56, 189, 248, 0.08) 15px
+      rgba(96, 165, 250, 0.08) 14px,
+      rgba(96, 165, 250, 0.08) 15px
     );
-  opacity: 0.4;
+  opacity: 0.45;
   pointer-events: none;
 }
 
@@ -113,18 +114,19 @@
 .title-card::after {
   content: '';
   position: absolute;
-  inset: 16px;
-  border-radius: 20px;
-  border: 1px solid rgba(148, 163, 184, 0.12);
-  opacity: 0.5;
+  inset: 18px;
+  border-radius: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  opacity: 0.55;
   pointer-events: none;
 }
 
 .title-card h2 {
   margin-top: 0;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   font-size: 20px;
+  color: var(--accent);
 }
 
 .team-status-grid {
@@ -136,13 +138,14 @@
 
 .team-card {
   position: relative;
-  background: rgba(8, 11, 24, 0.78);
-  border: 1px solid rgba(56, 189, 248, 0.2);
-  border-radius: 16px;
-  padding: 18px;
+  background: rgba(6, 11, 24, 0.82);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 20px;
   min-height: 170px;
-  box-shadow: 0 22px 48px rgba(2, 6, 23, 0.5);
+  box-shadow: 0 28px 60px rgba(5, 12, 30, 0.5);
   overflow: hidden;
+  backdrop-filter: blur(10px);
 }
 
 .team-card > * {
@@ -154,20 +157,23 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(135deg, rgba(56, 189, 248, 0.08), transparent 65%);
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.12), transparent 65%);
   opacity: 0.6;
   pointer-events: none;
 }
 
 .team-card h3 {
-  margin: 0 0 8px;
-  letter-spacing: 0.08em;
+  margin: 0 0 10px;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
+  font-size: 16px;
+  color: var(--text-strong);
 }
 
 .team-message {
   font-weight: 600;
   color: var(--accent-muted);
+  line-height: 1.6;
 }
 
 .team-errors {
@@ -178,9 +184,9 @@
 }
 
 .title-hint {
-  margin: 0 0 16px;
+  margin: 0 0 18px;
   color: var(--text-muted);
-  letter-spacing: 0.03em;
+  letter-spacing: 0.04em;
 }
 
 .title-actions {
@@ -190,43 +196,43 @@
 }
 
 button {
-  border: 1px solid rgba(56, 189, 248, 0.32);
+  border: 1px solid rgba(125, 211, 252, 0.3);
   border-radius: 999px;
-  padding: 12px 22px;
-  background: rgba(8, 11, 24, 0.65);
+  padding: 12px 24px;
+  background: rgba(7, 12, 24, 0.72);
   color: var(--text);
   font-size: 15px;
   font-weight: 600;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   cursor: pointer;
   transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-  box-shadow: 0 14px 30px rgba(2, 6, 23, 0.45);
-  backdrop-filter: blur(4px);
+  box-shadow: 0 18px 36px rgba(5, 12, 30, 0.5);
+  backdrop-filter: blur(6px);
 }
 
 button.primary {
-  background: linear-gradient(135deg, var(--accent) 0%, var(--highlight) 100%);
+  background: var(--accent-gradient);
   color: #020617;
   border: none;
   box-shadow:
-    0 16px 36px rgba(34, 211, 238, 0.35),
-    0 0 18px rgba(168, 85, 247, 0.25);
+    0 22px 44px rgba(96, 165, 250, 0.38),
+    0 0 18px rgba(192, 132, 252, 0.25);
 }
 
 button:hover:not(:disabled) {
   transform: translateY(-2px);
-  background: rgba(15, 23, 42, 0.75);
-  border-color: rgba(56, 189, 248, 0.5);
+  background: rgba(13, 19, 37, 0.78);
+  border-color: rgba(125, 211, 252, 0.5);
   box-shadow:
-    0 18px 40px rgba(2, 6, 23, 0.55),
-    0 0 12px rgba(56, 189, 248, 0.2);
+    0 22px 44px rgba(5, 12, 30, 0.6),
+    0 0 12px rgba(125, 211, 252, 0.25);
 }
 
 button.primary:hover:not(:disabled) {
-  background: linear-gradient(135deg, var(--accent) 0%, rgba(168, 85, 247, 0.92) 100%);
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.96) 0%, rgba(192, 132, 252, 0.96) 100%);
   box-shadow:
-    0 22px 44px rgba(34, 211, 238, 0.45),
-    0 0 20px rgba(168, 85, 247, 0.4);
+    0 26px 52px rgba(96, 165, 250, 0.5),
+    0 0 24px rgba(192, 132, 252, 0.45);
 }
 
 button:disabled {
@@ -237,7 +243,11 @@ button:disabled {
 
 button:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.35);
+  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.35);
+}
+
+button.primary:focus-visible {
+  box-shadow: 0 0 0 3px rgba(192, 132, 252, 0.4);
 }
 
 .toolbar {
@@ -245,12 +255,12 @@ button:focus-visible {
   justify-content: space-between;
   gap: 16px;
   padding: 20px 24px;
-  background: var(--surface-soft);
-  border: 1px solid rgba(56, 189, 248, 0.2);
-  border-radius: 20px;
+  background: linear-gradient(145deg, rgba(7, 12, 28, 0.88), rgba(26, 39, 72, 0.52));
+  border: 1px solid var(--border);
+  border-radius: 22px;
   margin-bottom: 20px;
-  box-shadow: 0 24px 56px rgba(2, 6, 23, 0.5);
-  backdrop-filter: blur(6px);
+  box-shadow: 0 30px 70px rgba(5, 12, 32, 0.5);
+  backdrop-filter: blur(10px);
 }
 
 .toolbar-left,
@@ -282,7 +292,7 @@ button:focus-visible {
   border: 1px solid rgba(56, 189, 248, 0.4);
   border-radius: 4px;
   padding: 2px 6px;
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-size: 0.9em;
   color: var(--accent-muted);
 }

--- a/baseball_sim/ui/web/static/css/modals.css
+++ b/baseball_sim/ui/web/static/css/modals.css
@@ -6,16 +6,19 @@
   align-items: center;
   justify-content: center;
   padding: 32px;
-  background: rgba(7, 11, 25, 0.7);
-  backdrop-filter: blur(4px);
+  background:
+    radial-gradient(circle at 20% 20%, rgba(96, 165, 250, 0.18), transparent 60%),
+    radial-gradient(circle at 80% 30%, rgba(192, 132, 252, 0.2), transparent 65%),
+    rgba(5, 8, 18, 0.72);
+  backdrop-filter: blur(10px);
   z-index: 2000;
 }
 
 .modal-card {
-  background: rgba(15, 23, 42, 0.96);
-  border-radius: 20px;
+  background: linear-gradient(150deg, rgba(7, 12, 26, 0.94), rgba(30, 41, 83, 0.6));
+  border-radius: 22px;
   border: 1px solid var(--border);
-  box-shadow: 0 30px 80px rgba(8, 47, 73, 0.5);
+  box-shadow: 0 40px 90px rgba(5, 12, 32, 0.55);
   width: min(560px, 100%);
   max-height: 90vh;
   display: flex;
@@ -40,13 +43,16 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 20px 24px 0;
+  padding: 24px 28px 0;
 }
 
 .modal-header h3 {
   margin: 0;
   font-size: 22px;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+  font-family: var(--font-heading);
+  text-transform: uppercase;
 }
 
 .modal-close {
@@ -54,21 +60,24 @@
   width: 38px;
   height: 38px;
   border-radius: 50%;
-  background: rgba(148, 163, 184, 0.18);
+  background: rgba(148, 163, 184, 0.2);
   font-size: 24px;
   line-height: 1;
   display: grid;
   place-items: center;
   color: var(--text-muted);
+  border: 1px solid rgba(125, 211, 252, 0.25);
+  transition: transform 0.2s ease, background 0.2s ease;
 }
 
 .modal-close:hover:not(:disabled) {
-  background: rgba(148, 163, 184, 0.32);
+  background: rgba(148, 163, 184, 0.35);
   color: var(--text);
+  transform: translateY(-1px);
 }
 
 .modal-body {
-  padding: 16px 24px 24px;
+  padding: 18px 28px 28px;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -76,7 +85,7 @@
 }
 
 .modal-footer {
-  padding: 0 24px 24px;
+  padding: 0 28px 28px;
   display: flex;
   flex-wrap: wrap;
   gap: 12px;
@@ -87,15 +96,16 @@
   margin: 0;
   color: var(--text-muted);
   font-size: 14px;
+  line-height: 1.7;
 }
 
 .current-batter {
-  padding: 10px 14px;
-  border-radius: 12px;
-  background: rgba(30, 41, 59, 0.85);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.78);
+  border: 1px solid rgba(125, 211, 252, 0.24);
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.04em;
 }
 
 .form-grid {
@@ -110,10 +120,10 @@
 }
 
 .defense-section {
-  background: rgba(17, 24, 39, 0.92);
-  border-radius: 18px;
-  border: 1px solid var(--border);
-  padding: 16px;
+  background: rgba(10, 16, 32, 0.9);
+  border-radius: 20px;
+  border: 1px solid rgba(125, 211, 252, 0.22);
+  padding: 18px;
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -137,9 +147,9 @@
 }
 
 .defense-field button.position-slot {
-  background: rgba(30, 41, 59, 0.85);
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  border-radius: 14px;
+  background: rgba(18, 28, 52, 0.85);
+  border: 1px solid rgba(125, 211, 252, 0.28);
+  border-radius: 16px;
   padding: 12px;
   display: flex;
   flex-direction: column;
@@ -166,13 +176,13 @@
 
 .defense-field button.position-slot:hover:not(:disabled) {
   transform: translateY(-2px);
-  border-color: rgba(249, 115, 22, 0.4);
+  border-color: rgba(96, 165, 250, 0.45);
 }
 
 .defense-field button.position-slot.selected {
   border-color: var(--accent);
-  box-shadow: 0 0 0 1px rgba(249, 115, 22, 0.35);
-  background: rgba(249, 115, 22, 0.15);
+  box-shadow: 0 0 0 1px rgba(96, 165, 250, 0.35);
+  background: rgba(96, 165, 250, 0.14);
 }
 
 .defense-field button.position-slot:disabled {

--- a/baseball_sim/ui/web/templates/index.html
+++ b/baseball_sim/ui/web/templates/index.html
@@ -4,6 +4,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Baseball Simulation</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Figtree:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=Zen+Kaku+Gothic+New:wght@400;500;700;900&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="{{ url_for('static', filename='css/base.css') }}" />
     <link rel="stylesheet" href="{{ url_for('static', filename='css/layout.css') }}" />
     <link rel="stylesheet" href="{{ url_for('static', filename='css/game.css') }}" />


### PR DESCRIPTION
## Summary
- add Google Fonts preconnects and load Figtree, Zen Kaku Gothic New, and IBM Plex Mono for the web client
- refresh the base theme with updated colors, gradients, and typography treatments across the header, insights, and layout components
- restyle game panels, controls, and modals to match the new accent palette and refined font scale

## Testing
- pytest *(fails: ModuleNotFoundError for joblib and torch)*

------
https://chatgpt.com/codex/tasks/task_e_68d2c58ddbcc8322b35a312a9a8028de