### PR TITLE
Enlarge web field layout and reposition controls

### DIFF
--- a/baseball_sim/ui/web/static/css/game.css
+++ b/baseball_sim/ui/web/static/css/game.css
@@ -1,8 +1,9 @@
 /* Game screen layout and field visuals */
 .game-layout {
   display: grid;
-  grid-template-columns: minmax(480px, 3fr) minmax(280px, 2fr);
-  gap: 24px;
+  grid-template-columns: minmax(520px, 3.5fr) minmax(300px, 1.5fr);
+  gap: 28px;
+  align-items: start;
 }
 
 .game-layout > .scoreboard {
@@ -12,7 +13,7 @@
 .field-column {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 24px;
 }
 
 .play-result-card {
@@ -40,6 +41,7 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+  margin-top: clamp(64px, 12vh, 160px);
 }
 
 .scoreboard {
@@ -207,12 +209,27 @@
 }
 
 .bases {
+  --field-size: clamp(320px, 55vw, 540px);
+  --field-radius: calc(var(--field-size) * 0.1);
+  --outfield-width: calc(var(--field-size) * 1.52);
+  --outfield-height: calc(var(--field-size) * 0.98);
+  --infield-size: calc(var(--field-size) * 0.72);
+  --baseline-size: calc(var(--field-size) * 0.43);
+  --baseline-border: clamp(2px, calc(var(--field-size) * 0.014), 8px);
+  --dirt-size: calc(var(--field-size) * 0.34);
+  --dirt-border: clamp(1px, calc(var(--field-size) * 0.007), 4px);
+  --mound-size: calc(var(--field-size) * 0.17);
+  --mound-border: clamp(1px, calc(var(--field-size) * 0.007), 4px);
+  --base-size: calc(var(--field-size) * 0.185);
+  --base-border: clamp(2px, calc(var(--field-size) * 0.007), 6px);
+  --plate-size: calc(var(--field-size) * 0.19);
+  --foul-line-width: clamp(3px, calc(var(--field-size) * 0.015), 6px);
   position: relative;
-  width: 280px;
-  height: 280px;
-  margin: clamp(32px, 8vh, 64px) auto 0;
+  width: var(--field-size);
+  height: var(--field-size);
+  margin: clamp(56px, 14vh, 136px) auto 0;
   background: radial-gradient(circle at 50% 92%, rgba(15, 23, 42, 0.32), rgba(3, 7, 18, 0.95));
-  border-radius: 30px;
+  border-radius: var(--field-radius);
   box-shadow: 0 40px 80px rgba(5, 12, 32, 0.6);
   overflow: visible;
   isolation: isolate;
@@ -226,26 +243,21 @@
 
 /* Outfield as a fan shape centered at home plate */
 .field-outfield {
-  /* Anchor bottom-center of this element to home plate (top: 80% -> bottom: 20% of .bases) */
-  width: 480px;
-  height: 280px;
+  width: var(--outfield-width);
+  height: var(--outfield-height);
   left: 50%;
-  bottom: 20%;
+  bottom: 18%;
   transform: translateX(-50%);
-  /* Fan-shaped fair territory (±45deg from the center line) */
   background: conic-gradient(
     from -45deg at 50% 100%,
     rgba(16, 185, 129, 0.96) 0deg 90deg,
     transparent 90deg 360deg
   );
-  /* Clip the fan to a circular arc radius from home (avoid rectangular fill) */
   -webkit-mask-image: radial-gradient(circle farthest-side at 50% 100%, #000 98%, transparent 100%);
   mask-image: radial-gradient(circle farthest-side at 50% 100%, #000 98%, transparent 100%);
   -webkit-mask-repeat: no-repeat;
   mask-repeat: no-repeat;
-  /* Soft outer shading to give depth without circular rings */
-  box-shadow:
-    0 18px 36px rgba(15, 23, 42, 0.45);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.45);
   z-index: 0;
 }
 
@@ -253,46 +265,46 @@
 .field-outfield::after { content: none; }
 
 .field-infield-grass {
-  width: 200px;
-  height: 200px;
+  width: var(--infield-size);
+  height: var(--infield-size);
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%) rotate(45deg);
-  border-radius: 28px;
+  border-radius: calc(var(--infield-size) * 0.14);
   background: linear-gradient(135deg, rgba(34, 197, 94, 0.95), rgba(15, 118, 110, 0.85));
   box-shadow: 0 12px 24px rgba(15, 23, 42, 0.35);
   z-index: 1;
 }
 
 .field-infield-baseline {
-  width: 120px;
-  height: 120px;
+  width: var(--baseline-size);
+  height: var(--baseline-size);
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%) rotate(45deg);
-  border-radius: 16px;
-  border: 4px solid rgba(248, 250, 252, 0.95);
+  border-radius: calc(var(--baseline-size) * 0.13);
+  border: var(--baseline-border) solid rgba(248, 250, 252, 0.95);
   z-index: 2;
   box-shadow: 0 0 14px rgba(248, 250, 252, 0.35);
 }
 
 .field-infield-dirt {
-  width: 96px;
-  height: 96px;
+  width: var(--dirt-size);
+  height: var(--dirt-size);
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%) rotate(45deg);
-  border-radius: 14px;
+  border-radius: calc(var(--dirt-size) * 0.15);
   background: linear-gradient(135deg, rgba(214, 162, 93, 0.95), rgba(168, 108, 43, 0.88));
-  border: 2px solid rgba(214, 162, 93, 0.8);
+  border: var(--dirt-border) solid rgba(214, 162, 93, 0.8);
   box-shadow: inset 0 0 18px rgba(107, 64, 31, 0.45);
   z-index: 3;
 }
 
 .foul-line {
-  width: 4px;
-  height: 260px;
-  bottom: 20%;
+  width: var(--foul-line-width);
+  height: calc(var(--field-size) * 0.95);
+  bottom: 18%;
   left: 50%;
   background: linear-gradient(180deg, rgba(248, 250, 252, 0.95), rgba(248, 250, 252, 0.2));
   transform-origin: bottom center;
@@ -310,14 +322,14 @@
 }
 
 .pitcher-mound {
-  width: 48px;
-  height: 48px;
+  width: var(--mound-size);
+  height: var(--mound-size);
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
   border-radius: 50%;
   background: radial-gradient(circle at 50% 40%, rgba(224, 180, 111, 0.95), rgba(163, 98, 40, 0.85));
-  border: 2px solid rgba(248, 250, 252, 0.35);
+  border: var(--mound-border) solid rgba(248, 250, 252, 0.35);
   box-shadow: 0 10px 20px rgba(15, 23, 42, 0.45);
   z-index: 5;
 }
@@ -333,11 +345,11 @@
 
 .base {
   position: absolute;
-  width: 52px;
-  height: 52px;
+  width: var(--base-size);
+  height: var(--base-size);
   transform: translate(-50%, -50%) rotate(45deg);
-  border: 2px solid rgba(15, 23, 42, 0.15);
-  border-radius: 14px;
+  border: var(--base-border) solid rgba(15, 23, 42, 0.15);
+  border-radius: calc(var(--base-size) * 0.27);
   background: rgba(248, 250, 252, 0.95);
   box-shadow: 0 12px 22px rgba(15, 23, 42, 0.45);
   display: flex;
@@ -350,7 +362,7 @@
 .base span {
   transform: rotate(-45deg);
   font-weight: 800;
-  font-size: 22px;
+  font-size: clamp(16px, calc(var(--field-size) * 0.07), 28px);
   color: rgba(248, 250, 252, 0.96);
   text-shadow: 0 0 6px rgba(15, 23, 42, 0.6);
 }
@@ -385,10 +397,10 @@
   top: 80%;
   left: 50%;
   transform: translate(-50%, -50%) rotate(45deg);
-  width: 54px;
-  height: 54px;
-  border: 2px solid rgba(148, 163, 184, 0.45);
-  border-radius: 14px;
+  width: var(--plate-size);
+  height: var(--plate-size);
+  border: var(--base-border) solid rgba(148, 163, 184, 0.45);
+  border-radius: calc(var(--plate-size) * 0.26);
   background: rgba(248, 250, 252, 0.95);
   box-shadow: 0 14px 26px rgba(15, 23, 42, 0.45);
   z-index: 6;
@@ -397,8 +409,8 @@
 .home-plate::after {
   content: '';
   position: absolute;
-  inset: 10px;
-  border-radius: 10px;
+  inset: clamp(6px, calc(var(--plate-size) * 0.18), 14px);
+  border-radius: calc(var(--plate-size) * 0.2);
   background: linear-gradient(135deg, rgba(148, 163, 184, 0.2), rgba(148, 163, 184, 0));
 }
 
@@ -553,6 +565,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 16px;
+  margin-top: clamp(56px, 10vh, 136px);
 }
 
 .roster {
@@ -602,6 +615,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 16px;
+  margin-top: clamp(32px, 7vh, 96px);
 }
 
 .pitcher-list {

--- a/baseball_sim/ui/web/static/css/responsive.css
+++ b/baseball_sim/ui/web/static/css/responsive.css
@@ -1,13 +1,24 @@
 /* Responsive overrides */
 @media (max-width: 600px) {
   .bases {
+    --field-size: clamp(240px, 80vw, 320px);
     margin: 32px auto 0;
   }
 
   .field-outfield {
-    width: 420px;
-    height: 420px;
     box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
+  }
+
+  .control-column {
+    margin-top: 24px;
+  }
+
+  .roster-panel {
+    margin-top: 28px;
+  }
+
+  .pitchers-panel {
+    margin-top: 20px;
   }
 
   .defense-alignment .player-chip {
@@ -28,6 +39,18 @@
 @media (max-width: 960px) {
   .game-layout {
     grid-template-columns: 1fr;
+  }
+
+  .control-column {
+    margin-top: 32px;
+  }
+
+  .roster-panel {
+    margin-top: 32px;
+  }
+
+  .pitchers-panel {
+    margin-top: 24px;
   }
 
   .header-topline {


### PR DESCRIPTION
## Summary
- enlarge the on-field graphic in the web UI with scalable sizing variables
- push the lineup tables and play controls further down the page to spotlight the field

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'joblib', 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68d2cd6482d08322acf50647c4c2f57a