### PR TITLE
Add web play result ball animations

### DIFF
--- a/baseball_sim/gameplay/utils.py
+++ b/baseball_sim/gameplay/utils.py
@@ -155,9 +155,12 @@ class BuntProcessor:
         # 得点があれば加算
         if runs_scored > 0:
             self.game_state._add_runs(runs_scored, batter)
-            return f"Bunt hit! {runs_scored} runs scored!"
-        
-        return "Bunt hit!"
+            message = f"Bunt hit! {runs_scored} runs scored!"
+        else:
+            message = "Bunt hit!"
+
+        self.game_state.record_play(GameResults.BUNT_SINGLE, message)
+        return message
     
     def _handle_sacrifice_bunt(self, batter):
         """送りバント成功の処理"""
@@ -190,13 +193,14 @@ class BuntProcessor:
         # 得点があれば加算
         if runs_scored > 0:
             self.game_state._add_runs(runs_scored, batter)
-            return f"Sacrifice bunt successful! {runs_scored} runs scored! {advance_message}"
-        
-        # 実際に進塁が発生した場合のみ「successful」と表示
-        if actual_advancement or runs_scored > 0:
-            return f"Sacrifice bunt successful! {advance_message}"
+            message = f"Sacrifice bunt successful! {runs_scored} runs scored! {advance_message}"
+        elif actual_advancement or runs_scored > 0:
+            message = f"Sacrifice bunt successful! {advance_message}"
         else:
-            return f"Sacrifice bunt attempted, but no advancement occurred. {advance_message}"
+            message = f"Sacrifice bunt attempted, but no advancement occurred. {advance_message}"
+
+        self.game_state.record_play(GameResults.SACRIFICE_BUNT, message)
+        return message
     
     def _handle_bunt_out(self, batter):
         """バントアウトの処理"""
@@ -210,9 +214,12 @@ class BuntProcessor:
         self.game_state.add_out()
         
         if runner_out_message:
-            return f"Bunt out! {runner_out_message}"
-        
-        return "Bunt out"
+            message = f"Bunt out! {runner_out_message}"
+        else:
+            message = "Bunt out"
+
+        self.game_state.record_play(GameResults.BUNT_OUT, message)
+        return message
     
     def _handle_bunt_failed(self, batter):
         """バント失敗の処理"""
@@ -226,9 +233,12 @@ class BuntProcessor:
         self.game_state.add_out()
         
         if additional_outs > 0:
-            return f"Bunt failed! {additional_outs} additional runner(s) out!"
-        
-        return "Bunt failed!"
+            message = f"Bunt failed! {additional_outs} additional runner(s) out!"
+        else:
+            message = "Bunt failed!"
+
+        self.game_state.record_play(GameResults.BUNT_FAILED, message)
+        return message
     
     def _advance_runners(self, bunt_type, batter=None):
         """統一的なランナー進塁処理"""

--- a/baseball_sim/ui/web/state_builders.py
+++ b/baseball_sim/ui/web/state_builders.py
@@ -180,6 +180,28 @@ class SessionStateBuilder:
         max_innings = max(len(scoreboard["away"]), len(scoreboard["home"]), 9)
         situation = format_situation(game_state)
 
+        last_play_raw = getattr(game_state, "last_play", None)
+        if isinstance(last_play_raw, dict):
+            raw_result = last_play_raw.get("result")
+            raw_message = last_play_raw.get("message", "")
+            raw_sequence = last_play_raw.get("sequence", 0)
+            result_text = raw_result if raw_result is None else str(raw_result)
+            if isinstance(raw_message, str):
+                message_text = raw_message
+            else:
+                message_text = str(raw_message)
+            if isinstance(raw_sequence, int):
+                sequence_number = raw_sequence
+            else:
+                try:
+                    sequence_number = int(raw_sequence)
+                except (TypeError, ValueError):
+                    sequence_number = getattr(game_state, "_play_sequence", 0)
+        else:
+            result_text = None
+            message_text = ""
+            sequence_number = getattr(game_state, "_play_sequence", 0)
+
         return (
             {
                 "active": True,
@@ -224,6 +246,11 @@ class SessionStateBuilder:
                 "situation": situation,
                 "matchup": format_matchup(current_batter, current_pitcher),
                 "max_innings": max_innings,
+                "last_play": {
+                    "result": result_text,
+                    "message": message_text,
+                    "sequence": sequence_number,
+                },
             },
             action_block_reason,
         )

--- a/baseball_sim/ui/web/static/css/game.css
+++ b/baseball_sim/ui/web/static/css/game.css
@@ -508,6 +508,96 @@
   color: var(--text);
 }
 
+.play-animation-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 11;
+  pointer-events: none;
+  overflow: visible;
+}
+
+.play-ball {
+  position: absolute;
+  width: clamp(10px, calc(var(--field-size) * 0.038), 18px);
+  height: clamp(10px, calc(var(--field-size) * 0.038), 18px);
+  border-radius: 50%;
+  background: radial-gradient(circle at 32% 32%, #fff 40%, #e2e8f0 68%, rgba(148, 163, 184, 0.45) 100%);
+  box-shadow: 0 0 12px rgba(148, 197, 255, 0.42);
+  transform: translate(-50%, -50%);
+  will-change: transform, opacity;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.play-ball::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: var(--trail-length, clamp(18px, calc(var(--field-size) * 0.08), 28px));
+  height: var(--trail-width, clamp(2px, calc(var(--field-size) * 0.01), 4px));
+  background: linear-gradient(90deg, var(--trail-color, rgba(255, 255, 255, 0.9)), transparent);
+  transform-origin: left center;
+  transform: translate(-100%, -50%) rotate(var(--trail-angle, 0deg));
+  opacity: var(--trail-opacity, 0.6);
+  filter: blur(var(--trail-blur, 1px));
+  pointer-events: none;
+}
+
+.play-ball--groundout {
+  --trail-color: rgba(248, 191, 143, 0.85);
+  --trail-length: clamp(18px, calc(var(--field-size) * 0.07), 26px);
+  --trail-opacity: 0.6;
+  box-shadow: 0 0 10px rgba(250, 204, 21, 0.4);
+}
+
+.play-ball--infield {
+  --trail-color: rgba(191, 219, 254, 0.9);
+  --trail-length: clamp(24px, calc(var(--field-size) * 0.1), 34px);
+  box-shadow: 0 0 16px rgba(96, 165, 250, 0.45);
+}
+
+.play-ball--outfield {
+  --trail-color: rgba(165, 243, 252, 0.85);
+  --trail-length: clamp(30px, calc(var(--field-size) * 0.14), 42px);
+  --trail-opacity: 0.55;
+  box-shadow: 0 0 20px rgba(56, 189, 248, 0.45);
+}
+
+.play-ball--single {
+  --trail-color: rgba(129, 140, 248, 0.85);
+  --trail-length: clamp(26px, calc(var(--field-size) * 0.11), 36px);
+  box-shadow: 0 0 14px rgba(129, 140, 248, 0.5);
+}
+
+.play-ball--extra-base {
+  --trail-color: rgba(110, 231, 183, 0.9);
+  --trail-length: clamp(34px, calc(var(--field-size) * 0.16), 48px);
+  --trail-opacity: 0.65;
+  box-shadow: 0 0 18px rgba(16, 185, 129, 0.5);
+}
+
+.play-ball--home-run {
+  --trail-color: rgba(253, 224, 71, 0.95);
+  --trail-length: clamp(40px, calc(var(--field-size) * 0.2), 56px);
+  --trail-opacity: 0.75;
+  --trail-blur: 1.6px;
+  box-shadow: 0 0 20px rgba(251, 191, 36, 0.75), 0 0 40px rgba(253, 224, 71, 0.35);
+  background: radial-gradient(circle at 35% 35%, #fff 28%, #fef08a 86%, rgba(251, 191, 36, 0.45) 100%);
+}
+
+.play-ball-spark {
+  position: absolute;
+  width: clamp(16px, calc(var(--field-size) * 0.08), 32px);
+  height: clamp(16px, calc(var(--field-size) * 0.08), 32px);
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(253, 224, 71, 0.9), rgba(253, 224, 71, 0));
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+  mix-blend-mode: screen;
+  z-index: 12;
+}
+
 .batter-alignment .batter-slot {
   position: absolute;
   transform: translate(-50%, -50%);

--- a/baseball_sim/ui/web/static/js/dom.js
+++ b/baseball_sim/ui/web/static/js/dom.js
@@ -47,6 +47,7 @@ export const elements = {
   offensePitchers: document.getElementById('offense-pitchers'),
   defensePitchers: document.getElementById('defense-pitchers'),
   baseState: document.getElementById('base-state'),
+  playAnimationLayer: document.getElementById('play-animation-layer'),
   defenseAlignment: document.getElementById('defense-alignment'),
   batterAlignment: document.getElementById('batter-alignment'),
   pinchPlayer: document.getElementById('pinch-player'),

--- a/baseball_sim/ui/web/static/js/ui/fieldAnimation.js
+++ b/baseball_sim/ui/web/static/js/ui/fieldAnimation.js
@@ -1,0 +1,267 @@
+import { elements } from '../dom.js';
+
+const RESULT_CATEGORY_MAP = {
+  groundout: 'groundout',
+  ground_out: 'groundout',
+  sacrifice_bunt: 'groundout',
+  bunt_out: 'groundout',
+  bunt_failed: 'groundout',
+  infield_flyout: 'infieldFly',
+  fly_out: 'outfieldFly',
+  outfield_flyout: 'outfieldFly',
+  single: 'single',
+  bunt_single: 'single',
+  double: 'extraBase',
+  triple: 'extraBase',
+  home_run: 'homeRun',
+};
+
+const CATEGORY_SETTINGS = {
+  groundout: {
+    className: 'play-ball--groundout',
+    distanceFactor: 0.42,
+    angleRange: [38, 142],
+    finalOpacity: 0.35,
+    jitter: 0.08,
+  },
+  infieldFly: {
+    className: 'play-ball--infield',
+    distanceFactor: 0.55,
+    angleRange: [46, 134],
+    finalOpacity: 0.35,
+    jitter: 0.12,
+  },
+  outfieldFly: {
+    className: 'play-ball--outfield',
+    distanceFactor: 0.9,
+    angleRange: [34, 146],
+    finalOpacity: 0.25,
+    jitter: 0.14,
+  },
+  single: {
+    className: 'play-ball--single',
+    distanceFactor: 0.68,
+    angleRange: [36, 144],
+    finalOpacity: 0.32,
+    jitter: 0.12,
+  },
+  extraBase: {
+    className: 'play-ball--extra-base',
+    distanceFactor: 0.98,
+    angleRange: [32, 148],
+    finalOpacity: 0.26,
+    jitter: 0.15,
+  },
+  homeRun: {
+    className: 'play-ball--home-run',
+    distanceFactor: 1.05,
+    angleRange: [28, 152],
+    finalOpacity: 0.18,
+    jitter: 0.18,
+    spark: true,
+  },
+};
+
+const BASE_SPEED = 0.52; // pixels per millisecond
+const MIN_DURATION = 360;
+const MAX_DURATION = 1400;
+let lastSequence = 0;
+
+function toNumber(value, fallback) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return fallback;
+}
+
+function clampDistance(layerRect, startX, startY, dx, dy, marginFactor) {
+  const margin = Math.min(layerRect.width, layerRect.height) * (marginFactor ?? 0.06);
+  const targetX = startX + dx;
+  const targetY = startY + dy;
+  let scale = 1;
+
+  if (targetX < margin) {
+    const candidate = (startX - margin) / (startX - targetX);
+    if (Number.isFinite(candidate) && candidate > 0) {
+      scale = Math.min(scale, candidate);
+    }
+  }
+  if (targetX > layerRect.width - margin) {
+    const candidate = (layerRect.width - margin - startX) / (targetX - startX);
+    if (Number.isFinite(candidate) && candidate > 0) {
+      scale = Math.min(scale, candidate);
+    }
+  }
+  if (targetY < margin) {
+    const candidate = (startY - margin) / (startY - targetY);
+    if (Number.isFinite(candidate) && candidate > 0) {
+      scale = Math.min(scale, candidate);
+    }
+  }
+
+  if (!Number.isFinite(scale) || scale <= 0) {
+    return { dx, dy };
+  }
+
+  if (scale < 1) {
+    return { dx: dx * scale, dy: dy * scale };
+  }
+  return { dx, dy };
+}
+
+function createSpark(layer, x, y) {
+  const spark = document.createElement('div');
+  spark.className = 'play-ball-spark';
+  spark.style.left = `${x}px`;
+  spark.style.top = `${y}px`;
+  layer.appendChild(spark);
+
+  const animation = spark.animate(
+    [
+      { transform: 'translate(-50%, -50%) scale(0.4)', opacity: 0.85 },
+      { transform: 'translate(-50%, -50%) scale(1.3)', opacity: 0 },
+    ],
+    { duration: 460, easing: 'ease-out' },
+  );
+
+  animation.finished
+    .catch(() => undefined)
+    .finally(() => {
+      spark.remove();
+    });
+}
+
+function performAnimation(settings) {
+  const layer = elements.playAnimationLayer;
+  const field = elements.baseState;
+  if (!layer || !field) {
+    return;
+  }
+
+  const homePlate = field.querySelector('.home-plate');
+  const fieldRect = field.getBoundingClientRect();
+  const layerRect = layer.getBoundingClientRect();
+
+  let startX = layerRect.width / 2;
+  let startY = layerRect.height * 0.8;
+  if (homePlate) {
+    const homeRect = homePlate.getBoundingClientRect();
+    startX = homeRect.left + homeRect.width / 2 - layerRect.left;
+    startY = homeRect.top + homeRect.height / 2 - layerRect.top;
+  } else if (fieldRect.width && fieldRect.height) {
+    startX = fieldRect.width / 2;
+    startY = fieldRect.height * 0.8;
+  }
+
+  const fieldSize = Math.min(layerRect.width, layerRect.height);
+  const jitter = settings.jitter ?? 0.1;
+  let distance = fieldSize * settings.distanceFactor;
+  distance += distance * (Math.random() - 0.5) * jitter;
+  distance = Math.max(distance, fieldSize * 0.2);
+
+  const [minAngle, maxAngle] = settings.angleRange;
+  const angleDeg = minAngle + Math.random() * Math.max(0, maxAngle - minAngle);
+  const angleRad = (angleDeg * Math.PI) / 180;
+
+  let dx = Math.cos(angleRad) * distance;
+  let dy = -Math.sin(angleRad) * distance;
+
+  const adjusted = clampDistance(layerRect, startX, startY, dx, dy, settings.marginFactor);
+  dx = adjusted.dx;
+  dy = adjusted.dy;
+
+  const endX = startX + dx;
+  const endY = startY + dy;
+  const actualDistance = Math.hypot(dx, dy);
+
+  const durationRaw = actualDistance / (settings.speed ?? BASE_SPEED);
+  const duration = Math.max(MIN_DURATION, Math.min(durationRaw, MAX_DURATION));
+  const finalOpacity = settings.finalOpacity ?? 0.3;
+
+  layer.innerHTML = '';
+  const ball = document.createElement('div');
+  const className = settings.className ? `play-ball ${settings.className}` : 'play-ball';
+  ball.className = className;
+  ball.style.left = `${startX}px`;
+  ball.style.top = `${startY}px`;
+  const trailAngle = (Math.atan2(dy, dx) * 180) / Math.PI;
+  ball.style.setProperty('--trail-angle', `${trailAngle}deg`);
+
+  layer.appendChild(ball);
+
+  const animation = ball.animate(
+    [
+      { transform: 'translate(-50%, -50%)', opacity: 1 },
+      {
+        transform: `translate(-50%, -50%) translate(${dx}px, ${dy}px)`,
+        opacity: finalOpacity,
+      },
+    ],
+    { duration, easing: 'linear' },
+  );
+
+  animation.finished
+    .then(() => {
+      if (settings.spark) {
+        createSpark(layer, endX, endY);
+      }
+    })
+    .catch(() => undefined)
+    .finally(() => {
+      ball.remove();
+    });
+}
+
+export function resetPlayAnimation() {
+  lastSequence = 0;
+  const layer = elements.playAnimationLayer;
+  if (layer) {
+    layer.innerHTML = '';
+  }
+}
+
+export function triggerPlayAnimation(lastPlay, { isActive = true } = {}) {
+  const layer = elements.playAnimationLayer;
+  const field = elements.baseState;
+  if (!layer || !field) {
+    return;
+  }
+
+  if (!isActive) {
+    resetPlayAnimation();
+    return;
+  }
+
+  if (!lastPlay) {
+    return;
+  }
+
+  const sequence = toNumber(lastPlay.sequence, null);
+  const result = lastPlay.result;
+  if (sequence === null || sequence <= lastSequence) {
+    return;
+  }
+  lastSequence = sequence;
+
+  if (!result) {
+    return;
+  }
+
+  const categoryKey = RESULT_CATEGORY_MAP[result];
+  if (!categoryKey) {
+    return;
+  }
+
+  const settings = CATEGORY_SETTINGS[categoryKey];
+  if (!settings) {
+    return;
+  }
+
+  performAnimation(settings);
+}

--- a/baseball_sim/ui/web/static/js/ui/renderers.js
+++ b/baseball_sim/ui/web/static/js/ui/renderers.js
@@ -32,6 +32,7 @@ import {
   resetDefenseSelectionsIfUnavailable,
 } from './defensePanel.js';
 import { setStatusMessage } from './status.js';
+import { triggerPlayAnimation, resetPlayAnimation } from './fieldAnimation.js';
 
 function setInsightsVisibility(visible) {
   const { insightGrid } = elements;
@@ -1438,6 +1439,7 @@ export function renderGame(gameState, teams, log) {
   setInsightsVisibility(isActiveGame);
 
   if (!isActiveGame) {
+    resetPlayAnimation();
     elements.gameScreen.classList.add('hidden');
     elements.titleScreen.classList.remove('hidden');
     updateScoreboard(gameState, teams);
@@ -1474,6 +1476,7 @@ export function renderGame(gameState, teams, log) {
   updateOutsIndicator(gameState.outs);
   elements.matchupText.textContent = gameState.matchup || '';
   updateBases(gameState.bases || []);
+  triggerPlayAnimation(gameState.last_play || null, { isActive: true });
 
   const offenseTeam = gameState.offense ? teams[gameState.offense] : null;
   const defenseTeam = gameState.defense ? teams[gameState.defense] : null;

--- a/baseball_sim/ui/web/templates/index.html
+++ b/baseball_sim/ui/web/templates/index.html
@@ -197,6 +197,11 @@
                   </div>
                 </div>
                 <div
+                  class="play-animation-layer"
+                  id="play-animation-layer"
+                  aria-hidden="true"
+                ></div>
+                <div
                   class="defense-alignment hidden"
                   id="defense-alignment"
                   aria-hidden="true"


### PR DESCRIPTION
## Summary
- record the last play result and message in `GameState`, including bunt-specific outcomes, and expose the sequence counter to the web state
- add a play animation layer, CSS, and a dedicated `fieldAnimation` module that drives six distinct constant-speed trajectories from home plate based on result type
- wire the animation trigger into the renderer and DOM so hits, fly outs, and grounders play unique visual feedback while walks/strikeouts remain unchanged

## Testing
- `pytest` *(fails: missing joblib/torch dependencies required by prediction model tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f09ac1988322a17983b246f960d1