### PR TITLE
Colorize ability metrics in web UI

### DIFF
--- a/baseball_sim/ui/web/static/css/base.css
+++ b/baseball_sim/ui/web/static/css/base.css
@@ -120,6 +120,18 @@ a:focus-visible {
   border: 0;
 }
 
+.ability-colorized {
+  --ability-color: var(--text);
+  --ability-intensity: 0;
+  color: var(--ability-color);
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  text-shadow: none;
+  transition: color 0.2s ease, text-shadow 0.2s ease, transform 0.2s ease;
+}
+
 .app-shell {
   min-height: 100vh;
   display: flex;

--- a/baseball_sim/ui/web/static/css/game.css
+++ b/baseball_sim/ui/web/static/css/game.css
@@ -1000,17 +1000,23 @@
   color: var(--text);
 }
 
-.matchup-batter-stats span {
+.matchup-batter-stats .matchup-batter-stat {
   display: flex;
   align-items: center;
   gap: 6px;
 }
 
-.matchup-batter-stats span strong {
+.matchup-batter-stats .matchup-batter-stat strong {
   font-family: var(--font-heading);
   font-size: 11px;
   letter-spacing: 0.12em;
   color: var(--text-muted);
+}
+
+.matchup-batter-stats .matchup-batter-stat-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
 }
 
 .matchup-empty {


### PR DESCRIPTION
## Summary
- add ability metric configuration and helper utilities to compute color styling for ability values
- apply the new coloring to the abilities modal, current matchup pitcher stats, and upcoming batter traits in the web UI
- introduce reusable CSS for ability values so numeric cells share consistent typography and spacing

## Testing
- pytest *(fails: missing optional dependencies joblib and torch)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f705e3648322bfce15d1be91f74e