### PR TITLE
Add fading field result overlay to web UI

### DIFF
--- a/baseball_sim/ui/web/static/css/game.css
+++ b/baseball_sim/ui/web/static/css/game.css
@@ -516,6 +516,107 @@
   overflow: visible;
 }
 
+.field-result-display {
+  position: absolute;
+  top: 44%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.92);
+  min-width: clamp(180px, 32vw, 360px);
+  padding: clamp(14px, 2.8vw, 28px) clamp(22px, 4.2vw, 40px);
+  border-radius: clamp(18px, 3vw, 36px);
+  text-align: center;
+  pointer-events: none;
+  z-index: 12;
+  font-family: var(--font-heading);
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  opacity: 0;
+  transition: opacity 0.45s ease, transform 0.45s ease;
+  backdrop-filter: blur(8px);
+  --result-color: #e0f2fe;
+  --result-glow: rgba(59, 130, 246, 0.32);
+  --result-border: rgba(96, 165, 250, 0.38);
+  --result-bg: linear-gradient(135deg, rgba(30, 64, 175, 0.32), rgba(15, 23, 42, 0.78));
+  color: var(--result-color);
+  text-shadow: 0 0 24px var(--result-glow);
+  border: 1px solid var(--result-border);
+  background: var(--result-bg);
+  box-shadow: 0 28px 60px var(--result-glow);
+}
+
+.field-result-display.is-visible {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.field-result-display.is-fading-out {
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(1.08);
+}
+
+.field-result-text {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(6px, 1.4vw, 12px);
+}
+
+.field-result-label {
+  font-size: clamp(28px, 5vw, 54px);
+  font-weight: 800;
+  letter-spacing: 0.16em;
+}
+
+.field-result-runs {
+  font-size: clamp(16px, 2.6vw, 24px);
+  font-weight: 600;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  opacity: 0.92;
+}
+
+.field-result-display[data-category='hit'] {
+  --result-color: #bbf7d0;
+  --result-glow: rgba(34, 197, 94, 0.52);
+  --result-border: rgba(74, 222, 128, 0.52);
+  --result-bg: linear-gradient(135deg, rgba(34, 197, 94, 0.26), rgba(6, 78, 59, 0.62));
+}
+
+.field-result-display[data-category='walk'] {
+  --result-color: #bae6fd;
+  --result-glow: rgba(56, 189, 248, 0.45);
+  --result-border: rgba(56, 189, 248, 0.48);
+  --result-bg: linear-gradient(135deg, rgba(14, 165, 233, 0.28), rgba(12, 74, 110, 0.6));
+}
+
+.field-result-display[data-category='strikeout'] {
+  --result-color: #fecaca;
+  --result-glow: rgba(248, 113, 113, 0.5);
+  --result-border: rgba(248, 113, 113, 0.52);
+  --result-bg: linear-gradient(135deg, rgba(248, 113, 113, 0.26), rgba(76, 29, 149, 0.58));
+}
+
+.field-result-display[data-category='out'] {
+  --result-color: #e2e8f0;
+  --result-glow: rgba(148, 163, 184, 0.4);
+  --result-border: rgba(148, 163, 184, 0.48);
+  --result-bg: linear-gradient(135deg, rgba(100, 116, 139, 0.28), rgba(15, 23, 42, 0.76));
+}
+
+.field-result-display[data-category='homerun'] {
+  --result-color: #fde68a;
+  --result-glow: rgba(251, 191, 36, 0.6);
+  --result-border: rgba(251, 191, 36, 0.52);
+  --result-bg: linear-gradient(135deg, rgba(250, 204, 21, 0.28), rgba(88, 28, 135, 0.6));
+}
+
+.field-result-display[data-category='neutral'] {
+  --result-color: #e0f2fe;
+  --result-glow: rgba(148, 163, 184, 0.36);
+  --result-border: rgba(148, 163, 184, 0.4);
+  --result-bg: linear-gradient(135deg, rgba(96, 165, 250, 0.22), rgba(15, 23, 42, 0.72));
+}
+
 .play-ball {
   position: absolute;
   width: clamp(10px, calc(var(--field-size) * 0.038), 18px);

--- a/baseball_sim/ui/web/static/js/dom.js
+++ b/baseball_sim/ui/web/static/js/dom.js
@@ -48,6 +48,7 @@ export const elements = {
   defensePitchers: document.getElementById('defense-pitchers'),
   baseState: document.getElementById('base-state'),
   playAnimationLayer: document.getElementById('play-animation-layer'),
+  fieldResultDisplay: document.getElementById('field-result-display'),
   defenseAlignment: document.getElementById('defense-alignment'),
   batterAlignment: document.getElementById('batter-alignment'),
   pinchPlayer: document.getElementById('pinch-player'),

--- a/baseball_sim/ui/web/static/js/ui/fieldResultDisplay.js
+++ b/baseball_sim/ui/web/static/js/ui/fieldResultDisplay.js
@@ -1,0 +1,207 @@
+import { elements } from '../dom.js';
+
+const HIT_RESULTS = new Set(['single', 'double', 'triple', 'bunt_single']);
+const WALK_RESULTS = new Set(['walk']);
+const STRIKEOUT_RESULTS = new Set(['strikeout']);
+const HOMERUN_RESULTS = new Set(['home_run']);
+const OUT_RESULTS = new Set([
+  'groundout',
+  'ground_out',
+  'fly_out',
+  'outfield_flyout',
+  'infield_flyout',
+  'sacrifice',
+  'sacrifice_bunt',
+  'bunt_out',
+  'bunt_failed',
+]);
+
+const LABEL_OVERRIDES = Object.freeze({
+  home_run: 'HOME RUN',
+  single: 'Single',
+  double: 'Double',
+  triple: 'Triple',
+  walk: 'Walk',
+  strikeout: 'Strikeout',
+  groundout: 'Out',
+  ground_out: 'Out',
+  fly_out: 'Out',
+  outfield_flyout: 'Out',
+  infield_flyout: 'Out',
+  sacrifice: 'Out',
+  sacrifice_bunt: 'Sacrifice Bunt',
+  bunt_out: 'Bunt Out',
+  bunt_failed: 'Bunt Failed',
+  bunt_single: 'Bunt Single',
+});
+
+const DISPLAY_DURATION = 2400;
+const FADE_DURATION = 650;
+
+let hideTimeoutId = null;
+let cleanupTimeoutId = null;
+let lastSequenceDisplayed = 0;
+
+function clearTimers() {
+  if (hideTimeoutId !== null) {
+    window.clearTimeout(hideTimeoutId);
+    hideTimeoutId = null;
+  }
+  if (cleanupTimeoutId !== null) {
+    window.clearTimeout(cleanupTimeoutId);
+    cleanupTimeoutId = null;
+  }
+}
+
+function hideDisplay() {
+  const container = elements.fieldResultDisplay;
+  clearTimers();
+  if (!container) return;
+  container.classList.remove('is-visible', 'is-fading-out');
+  container.innerHTML = '';
+  delete container.dataset.category;
+}
+
+export function resetFieldResultDisplay() {
+  lastSequenceDisplayed = 0;
+  hideDisplay();
+}
+
+function toLowerKey(value) {
+  if (typeof value === 'string') {
+    return value.toLowerCase();
+  }
+  return value == null ? '' : String(value).toLowerCase();
+}
+
+function determineCategory(resultKey) {
+  if (!resultKey) return 'neutral';
+  if (HOMERUN_RESULTS.has(resultKey)) return 'homerun';
+  if (STRIKEOUT_RESULTS.has(resultKey)) return 'strikeout';
+  if (WALK_RESULTS.has(resultKey)) return 'walk';
+  if (HIT_RESULTS.has(resultKey)) return 'hit';
+  if (OUT_RESULTS.has(resultKey)) return 'out';
+  return 'neutral';
+}
+
+function formatLabel(resultKey) {
+  if (!resultKey) return '';
+  if (LABEL_OVERRIDES[resultKey]) {
+    return LABEL_OVERRIDES[resultKey];
+  }
+  return resultKey
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function toScoreValue(value) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const numeric = Number.parseFloat(trimmed);
+    return Number.isFinite(numeric) ? numeric : null;
+  }
+  return null;
+}
+
+function computeRunsScored(gameState, previousGameState, offenseHint) {
+  if (!gameState || !gameState.score) return 0;
+  const offenseKey = offenseHint || gameState.offense || null;
+  if (!offenseKey) return 0;
+
+  const currentScore = toScoreValue(gameState.score?.[offenseKey]);
+  const previousScore = toScoreValue(previousGameState?.score?.[offenseKey]);
+  if (currentScore == null || previousScore == null) {
+    return 0;
+  }
+
+  const diff = currentScore - previousScore;
+  return diff > 0 ? diff : 0;
+}
+
+function setDisplayContent(container, label, runsScored) {
+  container.innerHTML = '';
+  const wrapper = document.createElement('div');
+  wrapper.className = 'field-result-text';
+
+  const labelEl = document.createElement('span');
+  labelEl.className = 'field-result-label';
+  labelEl.textContent = label;
+  wrapper.appendChild(labelEl);
+
+  if (runsScored > 0) {
+    const runsEl = document.createElement('span');
+    runsEl.className = 'field-result-runs';
+    runsEl.textContent = `${runsScored} ${runsScored === 1 ? 'Run' : 'Runs'}`;
+    wrapper.appendChild(runsEl);
+  }
+
+  container.appendChild(wrapper);
+}
+
+function showDisplay(container, category, label, runsScored) {
+  clearTimers();
+  container.classList.remove('is-visible', 'is-fading-out');
+  container.dataset.category = category;
+  setDisplayContent(container, label, runsScored);
+
+  // Force reflow so animations retrigger reliably
+  // eslint-disable-next-line no-unused-expressions
+  void container.offsetWidth;
+
+  container.classList.add('is-visible');
+  hideTimeoutId = window.setTimeout(() => {
+    container.classList.add('is-fading-out');
+    cleanupTimeoutId = window.setTimeout(() => {
+      container.classList.remove('is-visible', 'is-fading-out');
+      container.innerHTML = '';
+      delete container.dataset.category;
+    }, FADE_DURATION);
+  }, DISPLAY_DURATION);
+}
+
+export function updateFieldResultDisplay(gameState, previousGameState) {
+  const container = elements.fieldResultDisplay;
+  if (!container) {
+    if (gameState?.last_play?.sequence) {
+      lastSequenceDisplayed = Number(gameState.last_play.sequence) || lastSequenceDisplayed;
+    }
+    return;
+  }
+
+  if (!gameState || !gameState.active) {
+    resetFieldResultDisplay();
+    return;
+  }
+
+  const lastPlay = gameState.last_play || null;
+  if (!lastPlay || !lastPlay.result) {
+    hideDisplay();
+    return;
+  }
+
+  const sequence = Number(lastPlay.sequence) || 0;
+  if (!sequence || sequence === lastSequenceDisplayed) {
+    return;
+  }
+
+  const resultKey = toLowerKey(lastPlay.result);
+  const category = determineCategory(resultKey);
+  const label = formatLabel(resultKey);
+
+  if (!label) {
+    lastSequenceDisplayed = sequence;
+    return;
+  }
+
+  const runsScored = computeRunsScored(gameState, previousGameState, previousGameState?.offense);
+  showDisplay(container, category, label, runsScored);
+  lastSequenceDisplayed = sequence;
+}

--- a/baseball_sim/ui/web/static/js/ui/renderers.js
+++ b/baseball_sim/ui/web/static/js/ui/renderers.js
@@ -33,6 +33,7 @@ import {
 } from './defensePanel.js';
 import { setStatusMessage } from './status.js';
 import { triggerPlayAnimation, resetPlayAnimation } from './fieldAnimation.js';
+import { updateFieldResultDisplay, resetFieldResultDisplay } from './fieldResultDisplay.js';
 
 function setInsightsVisibility(visible) {
   const { insightGrid } = elements;
@@ -1601,7 +1602,7 @@ function updateStrategyControls(gameState, teams) {
   }
 }
 
-export function renderGame(gameState, teams, log) {
+export function renderGame(gameState, teams, log, previousGameState = null) {
   updateAnalyticsPanel(gameState);
   updateDefenseAlignment(gameState, teams);
   updateBatterAlignment(gameState, teams);
@@ -1610,6 +1611,7 @@ export function renderGame(gameState, teams, log) {
 
   if (!isActiveGame) {
     resetPlayAnimation();
+    resetFieldResultDisplay();
     elements.gameScreen.classList.add('hidden');
     elements.titleScreen.classList.remove('hidden');
     updateScoreboard(gameState, teams);
@@ -1647,6 +1649,7 @@ export function renderGame(gameState, teams, log) {
   elements.matchupText.textContent = gameState.matchup || '';
   updateBases(gameState.bases || []);
   triggerPlayAnimation(gameState.last_play || null, { isActive: true });
+  updateFieldResultDisplay(gameState, previousGameState || null);
 
   const offenseTeam = gameState.offense ? teams[gameState.offense] : null;
   const defenseTeam = gameState.defense ? teams[gameState.defense] : null;
@@ -1952,10 +1955,11 @@ export function updateAbilitiesPanel(state) {
 }
 
 export function render(data) {
+  const previousData = stateCache.data;
   stateCache.data = data;
   setStatusMessage(data.notification);
   renderTitle(data.title);
-  renderGame(data.game, data.teams, data.log);
+  renderGame(data.game, data.teams, data.log, previousData?.game || null);
   updateStatsPanel(data);
   updateAbilitiesPanel(data);
 }

--- a/baseball_sim/ui/web/templates/index.html
+++ b/baseball_sim/ui/web/templates/index.html
@@ -202,6 +202,12 @@
                   aria-hidden="true"
                 ></div>
                 <div
+                  class="field-result-display"
+                  id="field-result-display"
+                  aria-live="polite"
+                  aria-atomic="true"
+                ></div>
+                <div
                   class="defense-alignment hidden"
                   id="defense-alignment"
                   aria-hidden="true"


### PR DESCRIPTION
## Summary
- add a center-field overlay to surface the latest plate appearance result with timed fade out
- map backend play results to color-coded categories and include run totals when they change
- style the new overlay element and update render flow to drive it alongside existing animations

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'joblib'; ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68d2fc4a237c8322a70a027b826060ff