### PR TITLE
Fix team builder button not switching views

### DIFF
--- a/baseball_sim/ui/web/static/js/controllers/events.js
+++ b/baseball_sim/ui/web/static/js/controllers/events.js
@@ -8,7 +8,12 @@ import {
   toggleOffenseMenu,
 } from '../ui/menus.js';
 import { closeModal, openModal, resolveModal } from '../ui/modals.js';
-import { updateStatsPanel, updateAbilitiesPanel, render } from '../ui/renderers.js';
+import {
+  updateStatsPanel,
+  updateAbilitiesPanel,
+  render,
+  updateScreenVisibility,
+} from '../ui/renderers.js';
 import { showStatus } from '../ui/status.js';
 import { handleDefensePlayerClick, updateDefenseSelectionInfo } from '../ui/defensePanel.js';
 
@@ -61,6 +66,8 @@ function loadTeamTemplate() {
 function refreshView() {
   if (stateCache.data) {
     render(stateCache.data);
+  } else {
+    updateScreenVisibility();
   }
 }
 

--- a/baseball_sim/ui/web/static/js/ui/renderers.js
+++ b/baseball_sim/ui/web/static/js/ui/renderers.js
@@ -2445,7 +2445,7 @@ function renderTeamBuilder(teamLibraryState) {
   }
 }
 
-function updateScreenVisibility() {
+export function updateScreenVisibility() {
   const view = stateCache.uiView;
   const showLobby = view === 'lobby';
   const showBuilder = view === 'team-builder';


### PR DESCRIPTION
## Summary
- export the `updateScreenVisibility` helper so it can be reused outside the renderer
- update the lobby/team builder view refresh logic to fall back to direct visibility updates when no cached state exists

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d376344c90832295f91e9dc0fef455