### PR TITLE
Fix team builder player catalog loading hang

### DIFF
--- a/baseball_sim/ui/web/static/js/state.js
+++ b/baseball_sim/ui/web/static/js/state.js
@@ -18,6 +18,7 @@ export const stateCache = {
     editorDirty: false,
     form: null,
     players: { batters: [], pitchers: [], byId: {}, byName: {}, loaded: false, loading: false },
+    playersLoadingPromise: null,
     selection: { group: 'lineup', index: 0 },
     catalog: 'batters',
     searchTerm: '',


### PR DESCRIPTION
## Summary
- add a `playersLoadingPromise` handle to the team builder state cache so the UI can track in-flight catalog fetches
- update `ensureTeamBuilderPlayersLoaded` to reuse the shared promise and avoid returning early when the loader flag is set, ensuring the player list fetch completes

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3a984a3c08322b0268dc54fb6a82d