### PR TITLE
feat: swap lineup positions by selection

### DIFF
--- a/baseball_sim/ui/web/static/js/state.js
+++ b/baseball_sim/ui/web/static/js/state.js
@@ -20,6 +20,7 @@ export const stateCache = {
     players: { batters: [], pitchers: [], byId: {}, byName: {}, loaded: false, loading: false },
     playersLoadingPromise: null,
     selection: { group: 'lineup', index: 0 },
+    positionSwap: { first: null },
     catalog: 'batters',
     searchTerm: '',
   },


### PR DESCRIPTION
## Summary
- replace the lineup position cycling behavior with selecting two slots to swap their assignments
- persist selection state for swapping and reset it when loading or creating teams
- highlight the active position button so users can see which slot is selected for swapping

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3f4c3e8ec83229846d026d05f930e