### PR TITLE
Add lineup management controls to web title screen

### DIFF
--- a/baseball_sim/ui/web/routes.py
+++ b/baseball_sim/ui/web/routes.py
@@ -172,6 +172,28 @@ def create_routes(session: WebGameSession) -> Blueprint:
         state = session.reload_teams()
         return jsonify(state)
 
+    @api_bp.post("/teams/lineup")
+    def update_lineup() -> Dict[str, Any]:
+        payload = request.get_json(silent=True) or {}
+        team_key = payload.get("team")
+        lineup_payload = payload.get("lineup")
+        try:
+            state = session.update_starting_lineup(str(team_key), lineup_payload)
+        except GameSessionError as exc:
+            return create_error_response(str(exc), session)
+        return jsonify(state)
+
+    @api_bp.post("/teams/pitcher")
+    def update_starting_pitcher() -> Dict[str, Any]:
+        payload = request.get_json(silent=True) or {}
+        team_key = payload.get("team")
+        pitcher_name = payload.get("pitcher")
+        try:
+            state = session.set_starting_pitcher(str(team_key), pitcher_name)
+        except GameSessionError as exc:
+            return create_error_response(str(exc), session)
+        return jsonify(state)
+
     @api_bp.post("/teams/library/select")
     def select_team_files() -> Dict[str, Any]:
         payload = request.get_json(silent=True) or {}

--- a/baseball_sim/ui/web/static/css/layout.css
+++ b/baseball_sim/ui/web/static/css/layout.css
@@ -1025,6 +1025,212 @@
   font-size: 14px;
 }
 
+.title-roster-section {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.title-lineup-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.title-section-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.title-section-header h4 {
+  margin: 0;
+  font-size: 15px;
+  letter-spacing: 0.05em;
+  color: var(--text-strong);
+}
+
+.title-section-note {
+  font-size: 12px;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+}
+
+.title-lineup-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.title-lineup-row {
+  display: grid;
+  grid-template-columns: 42px 68px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(15, 23, 42, 0.58);
+  box-shadow: 0 12px 26px rgba(8, 14, 28, 0.32);
+}
+
+.title-lineup-order {
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--accent);
+  text-align: center;
+}
+
+.title-lineup-position {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--text-strong);
+  letter-spacing: 0.06em;
+}
+
+.title-lineup-select {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(10, 18, 34, 0.9);
+  color: var(--text);
+  font-size: 14px;
+  padding: 9px 12px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.title-lineup-select:focus-visible {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.75);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+  background: rgba(15, 23, 42, 0.95);
+}
+
+.title-lineup-select:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.title-lineup-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.title-lineup-apply {
+  border-radius: 999px;
+  padding: 8px 18px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  border: 1px solid rgba(96, 165, 250, 0.45);
+  background: rgba(30, 64, 175, 0.5);
+  color: var(--text-strong);
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.title-lineup-apply:hover:not(:disabled) {
+  border-color: rgba(125, 211, 252, 0.7);
+  background: rgba(37, 99, 235, 0.62);
+}
+
+.title-lineup-apply:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.title-bench-section h5 {
+  margin: 0 0 6px;
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.title-bench-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.title-bench-chip {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--text-muted);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+}
+
+.title-bench-empty {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.title-pitcher-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.title-pitcher-section h4 {
+  margin: 0;
+  font-size: 15px;
+  letter-spacing: 0.05em;
+  color: var(--text-strong);
+}
+
+.title-pitcher-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.title-pitcher-select {
+  flex: 1;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(10, 18, 34, 0.9);
+  color: var(--text);
+  font-size: 14px;
+  padding: 9px 12px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.title-pitcher-select:focus-visible {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.75);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+.title-pitcher-select:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.title-pitcher-apply {
+  border-radius: 999px;
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(30, 58, 138, 0.45);
+  color: var(--text-strong);
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.title-pitcher-apply:hover:not(:disabled) {
+  border-color: rgba(148, 163, 184, 0.6);
+  background: rgba(30, 64, 175, 0.58);
+}
+
+.title-pitcher-apply:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .title-hint {
   margin: 0 0 18px;
   color: var(--text-muted);

--- a/baseball_sim/ui/web/static/css/responsive.css
+++ b/baseball_sim/ui/web/static/css/responsive.css
@@ -166,4 +166,19 @@
   .defense-modal-body {
     grid-template-columns: 1fr;
   }
+
+  .title-lineup-row {
+    grid-template-columns: 34px 56px minmax(0, 1fr);
+    gap: 8px;
+  }
+
+  .title-pitcher-controls {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+  }
+
+  .title-pitcher-apply {
+    width: 100%;
+  }
 }

--- a/baseball_sim/ui/web/static/js/config.js
+++ b/baseball_sim/ui/web/static/js/config.js
@@ -21,6 +21,8 @@ export const CONFIG = {
       teamSave: '/api/teams/library/save',
       teamDelete: '/api/teams/library/delete',
       teamDetail: '/api/teams/library',
+      teamSetLineup: '/api/teams/lineup',
+      teamSetPitcher: '/api/teams/pitcher',
       // Player endpoints
       playersList: '/api/players/list',
       playersCatalog: '/api/players/catalog',

--- a/baseball_sim/ui/web/static/js/controllers/actions.js
+++ b/baseball_sim/ui/web/static/js/controllers/actions.js
@@ -310,6 +310,57 @@ export function createGameActions(render) {
     }
   }
 
+  async function handleLineupUpdate(teamKey, lineupEntries) {
+    const normalizedTeam = teamKey === 'home' ? 'home' : teamKey === 'away' ? 'away' : null;
+    if (!normalizedTeam) {
+      showStatus('スタメンを更新するチームを正しく選択してください。', 'danger');
+      return null;
+    }
+
+    if (!Array.isArray(lineupEntries) || !lineupEntries.length) {
+      showStatus('スタメンの候補が見つかりません。', 'danger');
+      return null;
+    }
+
+    try {
+      const payload = await apiRequest(CONFIG.api.endpoints.teamSetLineup, {
+        method: 'POST',
+        body: JSON.stringify({ team: normalizedTeam, lineup: lineupEntries }),
+      });
+      render(payload);
+      return payload;
+    } catch (error) {
+      handleApiError(error, render);
+      throw error;
+    }
+  }
+
+  async function handleSetStartingPitcher(teamKey, pitcherName) {
+    const normalizedTeam = teamKey === 'home' ? 'home' : teamKey === 'away' ? 'away' : null;
+    if (!normalizedTeam) {
+      showStatus('先発投手を設定するチームを正しく選択してください。', 'danger');
+      return null;
+    }
+
+    const normalizedName = typeof pitcherName === 'string' ? pitcherName.trim() : '';
+    if (!normalizedName) {
+      showStatus('先発投手を選択してください。', 'danger');
+      return null;
+    }
+
+    try {
+      const payload = await apiRequest(CONFIG.api.endpoints.teamSetPitcher, {
+        method: 'POST',
+        body: JSON.stringify({ team: normalizedTeam, pitcher: normalizedName }),
+      });
+      render(payload);
+      return payload;
+    } catch (error) {
+      handleApiError(error, render);
+      throw error;
+    }
+  }
+
   async function loadInitialState() {
     try {
       const initialState = await apiRequest(CONFIG.api.endpoints.gameState);
@@ -487,6 +538,8 @@ export function createGameActions(render) {
     handleDefenseSubstitution,
     handleDefenseReset,
     handlePitcherChange,
+    handleLineupUpdate,
+    handleSetStartingPitcher,
     loadInitialState,
     handleTeamSelection,
     fetchTeamDefinition,

--- a/baseball_sim/ui/web/templates/index.html
+++ b/baseball_sim/ui/web/templates/index.html
@@ -687,11 +687,65 @@
                 <h3 class="team-name" data-team="away">Away</h3>
                 <p class="team-message" data-team="away"></p>
                 <ul class="team-errors" data-team="away"></ul>
+                <div class="title-roster-section">
+                  <div class="title-lineup-section">
+                    <div class="title-section-header">
+                      <h4>スターティングラインナップ</h4>
+                      <span class="title-section-note" data-title-lineup-note="away"></span>
+                    </div>
+                    <div class="title-lineup-grid" data-title-lineup="away"></div>
+                    <div class="title-lineup-actions">
+                      <button type="button" class="title-lineup-apply" data-action="apply-lineup" data-team="away">
+                        スタメンを更新
+                      </button>
+                    </div>
+                  </div>
+                  <div class="title-bench-section">
+                    <h5>ベンチ</h5>
+                    <div class="title-bench-list" data-title-bench="away"></div>
+                  </div>
+                  <div class="title-pitcher-section">
+                    <h4>先発投手</h4>
+                    <div class="title-pitcher-controls">
+                      <select class="title-pitcher-select" data-team="away"></select>
+                      <button type="button" class="title-pitcher-apply" data-action="apply-pitcher" data-team="away">
+                        先発を設定
+                      </button>
+                    </div>
+                  </div>
+                </div>
               </div>
               <div class="team-card" id="home-team-card">
                 <h3 class="team-name" data-team="home">Home</h3>
                 <p class="team-message" data-team="home"></p>
                 <ul class="team-errors" data-team="home"></ul>
+                <div class="title-roster-section">
+                  <div class="title-lineup-section">
+                    <div class="title-section-header">
+                      <h4>スターティングラインナップ</h4>
+                      <span class="title-section-note" data-title-lineup-note="home"></span>
+                    </div>
+                    <div class="title-lineup-grid" data-title-lineup="home"></div>
+                    <div class="title-lineup-actions">
+                      <button type="button" class="title-lineup-apply" data-action="apply-lineup" data-team="home">
+                        スタメンを更新
+                      </button>
+                    </div>
+                  </div>
+                  <div class="title-bench-section">
+                    <h5>ベンチ</h5>
+                    <div class="title-bench-list" data-title-bench="home"></div>
+                  </div>
+                  <div class="title-pitcher-section">
+                    <h4>先発投手</h4>
+                    <div class="title-pitcher-controls">
+                      <select class="title-pitcher-select" data-team="home"></select>
+                      <button type="button" class="title-pitcher-apply" data-action="apply-pitcher" data-team="home">
+                        先発を設定
+                      </button>
+                    </div>
+                  </div>
+                </div>
               </div>
             </div>
             <p class="title-hint" id="title-hint"></p>


### PR DESCRIPTION
## Summary
- add session and API endpoints to update starting lineups and pitchers before a game
- extend the web title screen to configure batting orders, view bench players, and choose the starting pitcher
- wire up new frontend actions with validation plus styling updates for the lineup and pitcher controls

## Testing
- `pytest` *(fails: missing optional dependencies joblib/torch in test modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d5654d3adc832292ee64cc88de68f0