### PR TITLE
Enable interactive lineup editing on web title screen

### DIFF
--- a/baseball_sim/ui/web/static/css/layout.css
+++ b/baseball_sim/ui/web/static/css/layout.css
@@ -1090,27 +1090,66 @@
   letter-spacing: 0.06em;
 }
 
-.title-lineup-select {
+.title-lineup-player {
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
   border-radius: 10px;
-  border: 1px solid rgba(148, 163, 184, 0.28);
+  border: 1px solid rgba(148, 163, 184, 0.2);
   background: rgba(10, 18, 34, 0.9);
   color: var(--text);
   font-size: 14px;
-  padding: 9px 12px;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  padding: 10px 12px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+  text-align: left;
 }
 
-.title-lineup-select:focus-visible {
+.title-lineup-player:focus-visible {
   outline: none;
   border-color: rgba(96, 165, 250, 0.75);
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
   background: rgba(15, 23, 42, 0.95);
 }
 
-.title-lineup-select:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
+.title-lineup-player.empty {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.title-lineup-player-name {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.title-lineup-player-meta {
+  font-size: 12px;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+}
+
+.title-lineup-row.selected {
+  border-color: rgba(96, 165, 250, 0.75);
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.25);
+}
+
+.title-lineup-row.invalid {
+  border-color: rgba(248, 113, 113, 0.6);
+  box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.18);
+}
+
+.title-lineup-row.invalid .title-lineup-player {
+  background: rgba(127, 29, 29, 0.2);
+}
+
+.title-lineup-row.eligible .title-lineup-player {
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+.title-lineup-row.ineligible {
+  opacity: 0.6;
 }
 
 .title-lineup-actions {
@@ -1155,12 +1194,41 @@
 }
 
 .title-bench-chip {
-  padding: 4px 10px;
+  padding: 5px 12px;
   border-radius: 999px;
-  background: rgba(148, 163, 184, 0.2);
+  border: 1px solid transparent;
+  background: rgba(148, 163, 184, 0.18);
   color: var(--text-muted);
   font-size: 12px;
   letter-spacing: 0.04em;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+  cursor: pointer;
+}
+
+.title-bench-chip:hover {
+  border-color: rgba(96, 165, 250, 0.35);
+  color: var(--text);
+}
+
+.title-bench-chip:focus-visible {
+  outline: none;
+  border-color: rgba(96, 165, 250, 0.6);
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.25);
+}
+
+.title-bench-chip.selected {
+  background: rgba(30, 64, 175, 0.45);
+  border-color: rgba(59, 130, 246, 0.7);
+  color: var(--text);
+}
+
+.title-bench-chip.eligible {
+  border-color: rgba(96, 165, 250, 0.45);
+  color: var(--text);
+}
+
+.title-bench-chip.ineligible {
+  opacity: 0.55;
 }
 
 .title-bench-empty {

--- a/baseball_sim/ui/web/static/js/state.js
+++ b/baseball_sim/ui/web/static/js/state.js
@@ -16,6 +16,10 @@ export const stateCache = {
   playersTeamView: 'away',
   simulation: { running: false, defaultGames: 20, lastRun: null, log: [], limits: { min: 1, max: 200 } },
   teamLibrary: { teams: [], selection: { home: null, away: null }, ready: false, hint: '' },
+  titleLineup: {
+    plans: { home: null, away: null },
+    selection: { team: null, type: null, index: null },
+  },
   teamBuilder: {
     currentTeamId: null,
     lastSavedId: null,

--- a/baseball_sim/ui/web/static/js/ui/titleLineup.js
+++ b/baseball_sim/ui/web/static/js/ui/titleLineup.js
@@ -1,0 +1,278 @@
+import { stateCache, normalizePositionKey, canBenchPlayerCoverPosition } from '../state.js';
+
+function computeTeamSignature(teamData) {
+  if (!teamData) return '';
+  const lineup = Array.isArray(teamData?.lineup) ? teamData.lineup : [];
+  const bench = Array.isArray(teamData?.bench) ? teamData.bench : [];
+  const lineupSig = lineup
+    .map((player) => {
+      const name = player?.name || '';
+      const pos = normalizePositionKey(player?.position_key || player?.position) || '-';
+      return `${name}:${pos}`;
+    })
+    .join('|');
+  const benchSig = bench
+    .map((player) => player?.name || '')
+    .join('|');
+  return `${teamData?.name || ''}::${lineupSig}::${benchSig}`;
+}
+
+function clonePlayer(player, source) {
+  if (!player) return null;
+  const eligibleAll = Array.isArray(player.eligible_all)
+    ? player.eligible_all
+    : Array.isArray(player.eligible)
+    ? player.eligible
+    : [];
+  const normalizedEligibleAll = eligibleAll.map((pos) => String(pos || '').toUpperCase()).filter(Boolean);
+  const normalizedEligible = Array.isArray(player.eligible)
+    ? player.eligible.map((pos) => String(pos || '').toUpperCase()).filter(Boolean)
+    : [];
+  const clone = {
+    name: player.name || '',
+    position: player.position || player.position_key || '-',
+    position_key: normalizePositionKey(player.position_key || player.position) || '-',
+    eligible: normalizedEligible,
+    eligible_all: normalizedEligibleAll,
+    pitcher_type: player.pitcher_type || null,
+    bats: player.bats || null,
+    fielding_rating: player.fielding_rating || null,
+    fielding_value: Number.isFinite(player.fielding_value) ? Number(player.fielding_value) : null,
+    avg: player.avg || null,
+    hr: player.hr || null,
+    rbi: player.rbi || null,
+    source,
+    index: Number.isInteger(player.index) ? Number(player.index) : null,
+  };
+  return clone;
+}
+
+function updatePlayerForSlot(player, slot) {
+  if (!player || !slot) return;
+  player.position_key = slot.slotPositionKey || '-';
+  player.position = slot.slotPositionLabel || player.position || player.position_key || '-';
+  player.source = 'lineup';
+  if (Number.isInteger(slot.index)) {
+    player.index = slot.index;
+  }
+  player.order = slot.order;
+}
+
+function createPlan(teamKey, teamData, signature) {
+  const lineupEntries = Array.isArray(teamData?.lineup) ? teamData.lineup : [];
+  const benchEntries = Array.isArray(teamData?.bench) ? teamData.bench : [];
+  const plan = {
+    teamKey,
+    teamName: teamData?.name || '',
+    signature,
+    lineup: lineupEntries.map((entry, index) => {
+      const slotPositionKey = normalizePositionKey(entry?.position_key || entry?.position) || '-';
+      const slotPositionLabel = entry?.position || entry?.position_key || '-';
+      const slot = {
+        index,
+        order: Number.isInteger(entry?.order) ? entry.order : index + 1,
+        slotPositionKey,
+        slotPositionLabel,
+        player: clonePlayer(entry, 'lineup'),
+      };
+      if (slot.player) {
+        updatePlayerForSlot(slot.player, slot);
+      }
+      return slot;
+    }),
+    bench: benchEntries.map((entry, index) => {
+      const clone = clonePlayer(entry, 'bench');
+      if (clone) {
+        clone.index = index;
+        clone.source = 'bench';
+      }
+      return clone;
+    }).filter(Boolean),
+  };
+  reindexPlan(plan);
+  return plan;
+}
+
+function reindexPlan(plan) {
+  if (!plan) return;
+  plan.lineup.forEach((slot, index) => {
+    if (!slot) return;
+    slot.index = index;
+    slot.order = index + 1;
+    if (slot.player) {
+      slot.player.index = index;
+      slot.player.order = slot.order;
+      updatePlayerForSlot(slot.player, slot);
+    }
+  });
+  plan.bench.forEach((player, index) => {
+    if (!player) return;
+    player.index = index;
+    player.source = 'bench';
+  });
+}
+
+export function ensureTitleLineupPlan(teamKey, teamData, enabled) {
+  const normalizedKey = teamKey === 'home' ? 'home' : teamKey === 'away' ? 'away' : null;
+  if (!normalizedKey) {
+    return null;
+  }
+  if (!enabled || !teamData) {
+    stateCache.titleLineup.plans[normalizedKey] = null;
+    if (stateCache.titleLineup.selection.team === normalizedKey) {
+      clearTitleLineupSelection();
+    }
+    return null;
+  }
+  const signature = computeTeamSignature(teamData);
+  const existing = stateCache.titleLineup.plans[normalizedKey];
+  if (!existing || existing.signature !== signature) {
+    stateCache.titleLineup.plans[normalizedKey] = createPlan(normalizedKey, teamData, signature);
+    if (stateCache.titleLineup.selection.team === normalizedKey) {
+      clearTitleLineupSelection();
+    }
+  }
+  return stateCache.titleLineup.plans[normalizedKey];
+}
+
+export function getTitleLineupPlan(teamKey) {
+  const normalizedKey = teamKey === 'home' ? 'home' : teamKey === 'away' ? 'away' : null;
+  if (!normalizedKey) return null;
+  return stateCache.titleLineup.plans[normalizedKey] || null;
+}
+
+export function getTitleLineupSelection() {
+  return stateCache.titleLineup.selection || { team: null, type: null, index: null };
+}
+
+export function clearTitleLineupSelection() {
+  stateCache.titleLineup.selection = { team: null, type: null, index: null };
+}
+
+export function setTitleLineupSelection(teamKey, type, index) {
+  const normalizedKey = teamKey === 'home' ? 'home' : teamKey === 'away' ? 'away' : null;
+  if (!normalizedKey) {
+    clearTitleLineupSelection();
+    return;
+  }
+  if (type !== 'lineup' && type !== 'bench') {
+    clearTitleLineupSelection();
+    return;
+  }
+  if (!Number.isInteger(index) || index < 0) {
+    clearTitleLineupSelection();
+    return;
+  }
+  const plan = getTitleLineupPlan(normalizedKey);
+  if (!plan) {
+    clearTitleLineupSelection();
+    return;
+  }
+  if (type === 'lineup') {
+    if (!plan.lineup[index]) {
+      clearTitleLineupSelection();
+      return;
+    }
+  } else if (type === 'bench') {
+    if (!plan.bench[index]) {
+      clearTitleLineupSelection();
+      return;
+    }
+  }
+  stateCache.titleLineup.selection = { team: normalizedKey, type, index };
+}
+
+export function swapTitleLineupPlayers(teamKey, indexA, indexB) {
+  const plan = getTitleLineupPlan(teamKey);
+  if (!plan) return false;
+  if (!Number.isInteger(indexA) || !Number.isInteger(indexB)) return false;
+  if (indexA === indexB) return false;
+  const slotA = plan.lineup[indexA];
+  const slotB = plan.lineup[indexB];
+  if (!slotA || !slotB) return false;
+  const temp = slotA.player;
+  slotA.player = slotB.player || null;
+  slotB.player = temp || null;
+  if (slotA.player) {
+    updatePlayerForSlot(slotA.player, slotA);
+  }
+  if (slotB.player) {
+    updatePlayerForSlot(slotB.player, slotB);
+  }
+  reindexPlan(plan);
+  return true;
+}
+
+export function moveBenchPlayerToLineup(teamKey, benchIndex, lineupIndex) {
+  const plan = getTitleLineupPlan(teamKey);
+  if (!plan) return false;
+  if (!Number.isInteger(benchIndex) || !Number.isInteger(lineupIndex)) return false;
+  const slot = plan.lineup[lineupIndex];
+  if (!slot) return false;
+  if (benchIndex < 0 || benchIndex >= plan.bench.length) return false;
+  const incoming = plan.bench.splice(benchIndex, 1)[0];
+  if (!incoming) return false;
+  const outgoing = slot.player || null;
+  slot.player = incoming;
+  updatePlayerForSlot(slot.player, slot);
+  if (outgoing) {
+    outgoing.source = 'bench';
+    outgoing.position = outgoing.position || outgoing.position_key || '-';
+    outgoing.position_key = normalizePositionKey(outgoing.position_key || outgoing.position) || '-';
+    plan.bench.push(outgoing);
+  }
+  reindexPlan(plan);
+  return true;
+}
+
+export function getTitleLineupInvalidAssignments(plan) {
+  if (!plan) return [];
+  const invalid = [];
+  plan.lineup.forEach((slot) => {
+    if (!slot || !slot.player) return;
+    const positionKey = slot.slotPositionKey || normalizePositionKey(slot.player.position_key || slot.player.position);
+    if (!positionKey || positionKey === '-') return;
+    if (!canBenchPlayerCoverPosition(slot.player, positionKey)) {
+      invalid.push({ index: slot.index, positionKey, player: slot.player, slot });
+    }
+  });
+  return invalid;
+}
+
+export function getBenchEligibilityForPosition(plan, positionKey) {
+  if (!plan || !positionKey) return { eligible: new Set(), ineligible: new Set() };
+  const eligible = new Set();
+  const ineligible = new Set();
+  plan.bench.forEach((player, index) => {
+    if (!player) return;
+    if (canBenchPlayerCoverPosition(player, positionKey)) {
+      eligible.add(index);
+    } else {
+      ineligible.add(index);
+    }
+  });
+  return { eligible, ineligible };
+}
+
+export function getLineupEligibilityForBenchPlayer(plan, benchIndex) {
+  if (!plan) return { eligible: new Set(), ineligible: new Set() };
+  const benchPlayer = plan.bench[benchIndex];
+  if (!benchPlayer) return { eligible: new Set(), ineligible: new Set() };
+  const eligiblePositions = new Set(
+    Array.isArray(benchPlayer.eligible_all)
+      ? benchPlayer.eligible_all.map((pos) => String(pos || '').toUpperCase()).filter(Boolean)
+      : []
+  );
+  const eligible = new Set();
+  const ineligible = new Set();
+  plan.lineup.forEach((slot, index) => {
+    if (!slot) return;
+    const positionKey = slot.slotPositionKey || '-';
+    if (positionKey && eligiblePositions.has(positionKey)) {
+      eligible.add(index);
+    } else {
+      ineligible.add(index);
+    }
+  });
+  return { eligible, ineligible };
+}


### PR DESCRIPTION
## Summary
- add a dedicated title lineup plan manager that mirrors in-game defensive substitutions
- rework the title screen lineup renderer and events to support click-based swapping and bench assignments
- refresh title screen styles to highlight selections and eligibility while disabling incomplete lineups

## Testing
- pytest *(fails: missing optional dependencies `joblib` and `torch`)*

------
https://chatgpt.com/codex/tasks/task_e_68d56dddb9b083229a80904297fa1188