### PR TITLE
Remove unused NotificationCenter helpers

### DIFF
--- a/baseball_sim/ui/web/notifications.py
+++ b/baseball_sim/ui/web/notifications.py
@@ -30,21 +30,6 @@ class NotificationCenter:
         self._current = notification
         return notification
 
-    def set(self, notification: Optional[Notification]) -> None:
-        """Directly replace the stored notification."""
-
-        self._current = notification
-
-    def clear(self) -> None:
-        """Discard any stored notification."""
-
-        self._current = None
-
-    def peek(self) -> Optional[Notification]:
-        """Return the stored notification without clearing it."""
-
-        return self._current
-
     def consume(self) -> Optional[Notification]:
         """Return and clear the stored notification."""
 


### PR DESCRIPTION
## Summary
- remove unused NotificationCenter helper methods that are never invoked by the web session
- keep the notification API focused on the publish/consume flow that the UI relies on

## Testing
- pytest *(fails: missing optional dependencies joblib, torch)*

------
https://chatgpt.com/codex/tasks/task_e_68d61b3398c883228d82dbc02d5f78fb