### PR TITLE
Prevent team name from changing when editing rotation

### DIFF
--- a/baseball_sim/ui/static/js/controllers/events.js
+++ b/baseball_sim/ui/static/js/controllers/events.js
@@ -663,6 +663,8 @@ function clearRotationSlot(form, slotIndex) {
 
 function syncRotationWithPitchers(form) {
   if (!form) return;
+  const hadNameProperty = Object.prototype.hasOwnProperty.call(form, 'name');
+  const originalName = form.name;
   ensureRotationSlots(form);
   const pitchers = Array.isArray(form.pitchers) ? form.pitchers : [];
   const availableById = new Map();
@@ -691,6 +693,10 @@ function syncRotationWithPitchers(form) {
       form.rotation[index] = createEmptyRotationSlot(index);
     }
   });
+
+  if (hadNameProperty && form.name !== originalName) {
+    form.name = originalName;
+  }
 }
 
 function autoAssignPitcherToRotation(form, pitcherEntry, pitcherIndex) {


### PR DESCRIPTION
## Summary
- keep the team builder form name intact while syncing pitcher rotation slots
- ensure rotation updates no longer overwrite the saved team name

## Testing
- pytest *(fails: missing optional dependencies joblib/torch)*

------
https://chatgpt.com/codex/tasks/task_e_68d66332ff70832290c06ac1c6d0146d