### PR TITLE
Add dedicated squeeze bunt action

### DIFF
--- a/baseball_sim/config/constants.py
+++ b/baseball_sim/config/constants.py
@@ -77,6 +77,8 @@ class GameResults:
     SACRIFICE_BUNT = "sacrifice_bunt"
     BUNT_OUT = "bunt_out"
     BUNT_FAILED = "bunt_failed"
+    SQUEEZE_SUCCESS = "squeeze_success"
+    SQUEEZE_FAIL = "squeeze_fail"
 
     # 良い結果（攻撃側にとって）
     POSITIVE_RESULTS = [
@@ -89,10 +91,19 @@ class GameResults:
         BUNT_SINGLE,
         SACRIFICE_BUNT,
         STOLEN_BASE,
+        SQUEEZE_SUCCESS,
     ]
 
     # アウトになる結果
-    OUT_RESULTS = [STRIKEOUT, GROUND_OUT, FLY_OUT, BUNT_OUT, BUNT_FAILED, CAUGHT_STEALING]
+    OUT_RESULTS = [
+        STRIKEOUT,
+        GROUND_OUT,
+        FLY_OUT,
+        BUNT_OUT,
+        BUNT_FAILED,
+        CAUGHT_STEALING,
+        SQUEEZE_FAIL,
+    ]
 
     # バント関連の結果
     BUNT_RESULTS = [BUNT_SINGLE, SACRIFICE_BUNT, BUNT_OUT, BUNT_FAILED]

--- a/baseball_sim/gameplay/game.py
+++ b/baseball_sim/gameplay/game.py
@@ -222,6 +222,12 @@ class GameState:
             return False
         return True
 
+    def can_squeeze(self):
+        """スクイズが可能かどうかを判定"""
+        if self.outs >= 2:
+            return False
+        return bool(self._bases[2])
+
     def can_steal(self) -> bool:
         """盗塁が可能かどうかを判定"""
         first_runner = self._bases[0]
@@ -254,6 +260,13 @@ class GameState:
 
         bunt_processor = BuntProcessor(self)
         return bunt_processor.execute(batter, pitcher)
+
+    def execute_squeeze(self, batter, pitcher):
+        """スクイズプレーを実行し、結果を返す"""
+        from baseball_sim.gameplay.utils import SqueezeProcessor
+
+        squeeze_processor = SqueezeProcessor(self)
+        return squeeze_processor.execute(batter, pitcher)
 
     def _steal_success_probability(self, runner) -> float:
         base_rate = 0.7

--- a/baseball_sim/ui/cpu_strategy.py
+++ b/baseball_sim/ui/cpu_strategy.py
@@ -16,6 +16,7 @@ class CPUPlayType(str, Enum):
     SWING = "swing"
     BUNT = "bunt"
     STEAL = "steal"
+    SQUEEZE = "squeeze"
 
 
 @dataclass(frozen=True)
@@ -238,6 +239,25 @@ def select_offense_play(game_state, offense_team) -> CPUOffenseDecision:
             }
             label = "好走者を活かして盗塁を狙います。"
             return CPUOffenseDecision(CPUPlayType.STEAL, label=label, metadata=metadata)
+
+    if (
+        game_state.can_squeeze()
+        and has_runner_on(2)
+        and outs <= 1
+        and (inning >= 6 or margin <= 0)
+    ):
+        third_speed = getattr(bases[2], "speed", 100.0) or 100.0
+        batter_k_rate = getattr(batter, "k_pct", 25.0) or 25.0
+        leverage_factor = 0.35 if inning >= 7 and abs(margin) <= 1 else 0.0
+        risk_factor = random.random()
+        if third_speed + leverage_factor >= 100.0 or batter_k_rate >= 26.0 or risk_factor < 0.3:
+            metadata = {
+                "base_state": base_signature,
+                "third_speed": third_speed,
+                "k_pct": batter_k_rate,
+            }
+            label = "スクイズで三塁走者をホームに突入させます。"
+            return CPUOffenseDecision(CPUPlayType.SQUEEZE, label=label, metadata=metadata)
 
     if (
         game_state.can_bunt()

--- a/baseball_sim/ui/routes.py
+++ b/baseball_sim/ui/routes.py
@@ -95,6 +95,14 @@ def create_routes(session: WebGameSession) -> Blueprint:
             return create_error_response(str(exc), session)
         return jsonify(state)
 
+    @api_bp.post("/game/squeeze")
+    def squeeze() -> Dict[str, Any]:
+        try:
+            state = session.execute_squeeze()
+        except GameSessionError as exc:
+            return create_error_response(str(exc), session)
+        return jsonify(state)
+
     @api_bp.post("/game/progress")
     def progress() -> Dict[str, Any]:
         try:

--- a/baseball_sim/ui/state_builders.py
+++ b/baseball_sim/ui/state_builders.py
@@ -308,6 +308,10 @@ class SessionStateBuilder:
                 }
             )
 
+        bunt_visible = not (
+            game_state.can_squeeze() and not game_state.bases[0]
+        )
+
         return (
             {
                 "active": True,
@@ -336,11 +340,16 @@ class SessionStateBuilder:
                     and not game_state.game_ended
                     and offense_allowed
                     and game_state.can_bunt(),
+                    "squeeze": allowed
+                    and not game_state.game_ended
+                    and offense_allowed
+                    and game_state.can_squeeze(),
                     "steal": allowed
                     and not game_state.game_ended
                     and offense_allowed
                     and game_state.can_steal(),
                     "progress": progress_available and not game_state.game_ended,
+                    "show_bunt": bunt_visible,
                 },
                 "action_block_reason": action_block_reason if not allowed else None,
                 "defensive_errors": list(game_state.defensive_error_messages),

--- a/baseball_sim/ui/static/js/config.js
+++ b/baseball_sim/ui/static/js/config.js
@@ -9,6 +9,7 @@ export const CONFIG = {
       gameStop: '/api/game/stop',
       gameSwing: '/api/game/swing',
       gameBunt: '/api/game/bunt',
+      gameSqueeze: '/api/game/squeeze',
       gameProgress: '/api/game/progress',
       strategySteal: '/api/strategy/steal',
       pinchHit: '/api/strategy/pinch_hit',

--- a/baseball_sim/ui/static/js/controllers/actions.js
+++ b/baseball_sim/ui/static/js/controllers/actions.js
@@ -138,6 +138,15 @@ export function createGameActions(render) {
     }
   }
 
+  async function handleSqueeze() {
+    try {
+      const payload = await apiRequest(CONFIG.api.endpoints.gameSqueeze, { method: 'POST' });
+      render(payload);
+    } catch (error) {
+      handleApiError(error, render);
+    }
+  }
+
   async function handleProgress() {
     try {
       const payload = await apiRequest(CONFIG.api.endpoints.gameProgress, { method: 'POST' });
@@ -551,6 +560,7 @@ export function createGameActions(render) {
     startSimulation: handleSimulationStart,
     handleSwing,
     handleBunt,
+    handleSqueeze,
     handleProgress,
     handleSteal,
     handlePinchHit,

--- a/baseball_sim/ui/static/js/controllers/events.js
+++ b/baseball_sim/ui/static/js/controllers/events.js
@@ -3041,6 +3041,9 @@ export function initEventListeners(actions) {
   elements.clearLog.addEventListener('click', actions.handleClearLog);
   elements.swingButton.addEventListener('click', actions.handleSwing);
   elements.buntButton.addEventListener('click', actions.handleBunt);
+  if (elements.squeezeButton) {
+    elements.squeezeButton.addEventListener('click', actions.handleSqueeze);
+  }
   if (elements.stealButton) {
     elements.stealButton.addEventListener('click', actions.handleSteal);
   }

--- a/baseball_sim/ui/static/js/dom.js
+++ b/baseball_sim/ui/static/js/dom.js
@@ -27,6 +27,7 @@ export const elements = {
   clearLog: document.getElementById('clear-log'),
   swingButton: document.getElementById('swing-button'),
   buntButton: document.getElementById('bunt-button'),
+  squeezeButton: document.getElementById('squeeze-button'),
   stealButton: document.getElementById('steal-button'),
   progressButton: document.getElementById('progress-button'),
   openOffenseButton: document.getElementById('open-offense-strategy'),

--- a/baseball_sim/ui/static/js/ui/fieldAnimation.js
+++ b/baseball_sim/ui/static/js/ui/fieldAnimation.js
@@ -6,6 +6,8 @@ const RESULT_CATEGORY_MAP = {
   sacrifice_bunt: 'groundout',
   bunt_out: 'groundout',
   bunt_failed: 'groundout',
+  squeeze_success: 'groundout',
+  squeeze_fail: 'groundout',
   infield_flyout: 'infieldFly',
   fly_out: 'outfieldFly',
   outfield_flyout: 'outfieldFly',

--- a/baseball_sim/ui/static/js/ui/fieldResultDisplay.js
+++ b/baseball_sim/ui/static/js/ui/fieldResultDisplay.js
@@ -15,6 +15,8 @@ const OUT_RESULTS = new Set([
   'sacrifice_bunt',
   'bunt_out',
   'bunt_failed',
+  'squeeze_success',
+  'squeeze_fail',
   'caught_stealing',
 ]);
 
@@ -34,6 +36,8 @@ const LABEL_OVERRIDES = Object.freeze({
   sacrifice_bunt: 'Sacrifice Bunt',
   bunt_out: 'Bunt Out',
   bunt_failed: 'Bunt Failed',
+  squeeze_success: 'Squeeze Success',
+  squeeze_fail: 'Squeeze Failed',
   bunt_single: 'Bunt Single',
   stolen_base: 'Stolen Base',
   caught_stealing: 'Caught Stealing',

--- a/baseball_sim/ui/static/js/ui/renderers.js
+++ b/baseball_sim/ui/static/js/ui/renderers.js
@@ -2815,6 +2815,11 @@ export function renderGame(gameState, teams, log, previousGameState = null) {
     elements.actionWarning.textContent = '';
     elements.swingButton.disabled = true;
     elements.buntButton.disabled = true;
+    if (elements.squeezeButton) {
+      elements.squeezeButton.disabled = true;
+      elements.squeezeButton.textContent = 'スクイズ';
+      elements.squeezeButton.classList.remove('hidden');
+    }
     if (elements.stealButton) {
       elements.stealButton.disabled = true;
       elements.stealButton.textContent = '盗塁';
@@ -2825,6 +2830,9 @@ export function renderGame(gameState, teams, log, previousGameState = null) {
     }
     elements.swingButton.classList.remove('hidden');
     elements.buntButton.classList.remove('hidden');
+    if (elements.squeezeButton) {
+      elements.squeezeButton.classList.remove('hidden');
+    }
     if (elements.stealButton) {
       elements.stealButton.classList.remove('hidden');
     }
@@ -2902,6 +2910,10 @@ export function renderGame(gameState, teams, log, previousGameState = null) {
     elements.buntButton.disabled = true;
     elements.swingButton.textContent = 'Game Over';
     elements.buntButton.textContent = 'Game Over';
+    if (elements.squeezeButton) {
+      elements.squeezeButton.disabled = true;
+      elements.squeezeButton.textContent = 'Game Over';
+    }
     if (elements.stealButton) {
       elements.stealButton.disabled = true;
       elements.stealButton.textContent = 'Game Over';
@@ -2913,9 +2925,16 @@ export function renderGame(gameState, teams, log, previousGameState = null) {
     elements.actionWarning.textContent = 'ゲーム終了 - 新しい試合を開始するか、タイトルに戻ってください';
   } else {
     elements.swingButton.disabled = !gameState.actions?.swing;
-    elements.buntButton.disabled = !gameState.actions?.bunt;
+    const showBunt = Boolean(gameState.actions?.show_bunt ?? true);
+    const buntAllowed = Boolean(gameState.actions?.bunt);
+    elements.buntButton.disabled = !(buntAllowed && showBunt);
     elements.swingButton.textContent = '通常打撃';
     elements.buntButton.textContent = 'バント';
+    if (elements.squeezeButton) {
+      const squeezeAllowed = Boolean(gameState.actions?.squeeze);
+      elements.squeezeButton.disabled = !squeezeAllowed;
+      elements.squeezeButton.textContent = 'スクイズ';
+    }
     if (elements.stealButton) {
       elements.stealButton.disabled = !gameState.actions?.steal;
       elements.stealButton.textContent = '盗塁';
@@ -2927,7 +2946,12 @@ export function renderGame(gameState, teams, log, previousGameState = null) {
     }
     const hideOffenseActions = progressAllowed && controlInfo.mode === 'cpu';
     elements.swingButton.classList.toggle('hidden', hideOffenseActions);
-    elements.buntButton.classList.toggle('hidden', hideOffenseActions);
+    const buntVisible = showBunt && !hideOffenseActions;
+    elements.buntButton.classList.toggle('hidden', !buntVisible);
+    if (elements.squeezeButton) {
+      const squeezeVisible = Boolean(gameState.actions?.squeeze) && !hideOffenseActions;
+      elements.squeezeButton.classList.toggle('hidden', !squeezeVisible);
+    }
     if (elements.stealButton) {
       elements.stealButton.classList.toggle('hidden', hideOffenseActions);
     }

--- a/baseball_sim/ui/templates/index.html
+++ b/baseball_sim/ui/templates/index.html
@@ -998,6 +998,7 @@
                 <div class="action-buttons">
                   <button id="swing-button" class="primary">通常打撃</button>
                   <button id="bunt-button">バント</button>
+                  <button id="squeeze-button" class="hidden">スクイズ</button>
                   <button id="steal-button">盗塁</button>
                   <button id="progress-button" class="primary hidden">進行</button>
                   <button id="open-offense-strategy">攻撃側采配</button>


### PR DESCRIPTION
## Summary
- add a squeeze-specific processor and game state hooks so sacrifice bunts no longer trigger squeeze logic implicitly
- expose a separate squeeze control in the UI and wire up new API/controller handlers while adjusting result displays
- update CPU strategy to decide between bunting and squeeze attempts independently based on base state and game context

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d692d25b3483228f2b5057f562e6db