### PR TITLE
Revamp home screen with analytics-forward hero

### DIFF
--- a/baseball_sim/ui/static/css/base.css
+++ b/baseball_sim/ui/static/css/base.css
@@ -182,6 +182,364 @@ a:focus-visible {
   gap: 24px;
 }
 
+.hero-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 1.1fr) minmax(220px, 1fr) minmax(220px, 0.9fr);
+  gap: 20px;
+  align-items: stretch;
+}
+
+@media (max-width: 1080px) {
+  .hero-grid {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
+}
+
+.hero-grid section {
+  position: relative;
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: linear-gradient(150deg, rgba(6, 12, 26, 0.92), rgba(23, 34, 64, 0.58));
+  box-shadow:
+    0 30px 60px rgba(5, 12, 30, 0.55),
+    inset 0 0 0 1px rgba(15, 23, 42, 0.6);
+  padding: 22px clamp(18px, 4vw, 26px);
+  overflow: hidden;
+  backdrop-filter: blur(14px);
+}
+
+.hero-grid section::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 18% 18%, rgba(96, 165, 250, 0.26), transparent 60%);
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.hero-grid section > * {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-scoreboard-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  font-family: var(--font-mono);
+  letter-spacing: 0.08em;
+}
+
+.scoreboard-label {
+  margin: 0;
+  font-size: 12px;
+  color: rgba(191, 219, 254, 0.72);
+  text-transform: uppercase;
+}
+
+.scoreboard-clock {
+  font-size: 12px;
+  color: var(--accent-muted);
+}
+
+.scoreboard-body {
+  margin-top: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.scoreboard-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(125, 211, 252, 0.28);
+  background: linear-gradient(160deg, rgba(7, 14, 28, 0.88), rgba(12, 22, 44, 0.75));
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.14);
+}
+
+.scoreboard-row.is-home {
+  border-color: rgba(96, 165, 250, 0.52);
+  box-shadow:
+    inset 0 0 0 1px rgba(148, 163, 184, 0.18),
+    0 12px 28px rgba(14, 28, 56, 0.36);
+}
+
+.scoreboard-team {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.team-abbr {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: rgba(96, 165, 250, 0.16);
+  border: 1px solid rgba(125, 211, 252, 0.32);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.18em;
+}
+
+.team-name {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.scoreboard-score {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: flex-end;
+}
+
+.scoreboard-score .runs {
+  font-size: clamp(32px, 4.4vw, 40px);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--text-strong);
+  text-shadow:
+    0 12px 28px rgba(5, 12, 28, 0.55),
+    0 0 24px rgba(96, 165, 250, 0.26);
+}
+
+.scoreboard-score .runs.highlight {
+  color: var(--accent);
+}
+
+.scoreboard-score .detail {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.scoreboard-trend {
+  margin-top: 20px;
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  height: 70px;
+  padding: 12px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(96, 165, 250, 0.26);
+  background: linear-gradient(180deg, rgba(8, 15, 32, 0.9), rgba(4, 8, 18, 0.96));
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.66);
+}
+
+.scoreboard-trend span {
+  flex: 1;
+  display: block;
+  height: var(--p);
+  border-radius: 6px 6px 2px 2px;
+  background: linear-gradient(180deg, rgba(96, 165, 250, 0.9), rgba(56, 189, 248, 0.55));
+  box-shadow: 0 8px 20px rgba(56, 189, 248, 0.3);
+}
+
+.scoreboard-footer {
+  margin-top: 18px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+}
+
+.scoreboard-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 110px;
+}
+
+.meta-label {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(191, 219, 254, 0.64);
+}
+
+.meta-value {
+  font-size: 16px;
+  letter-spacing: 0.08em;
+}
+
+.meta-value.accent {
+  color: var(--accent);
+}
+
+.hero-spotlight {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.hero-spotlight h3,
+.hero-lab h3 {
+  margin: 0;
+  font-size: 15px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent-muted);
+}
+
+.spotlight-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.spotlight-list li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  row-gap: 10px;
+  align-items: center;
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(125, 211, 252, 0.18);
+  background: linear-gradient(150deg, rgba(7, 12, 26, 0.82), rgba(16, 25, 50, 0.78));
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.55);
+}
+
+.spotlight-label {
+  font-size: 13px;
+  color: var(--text-muted);
+  letter-spacing: 0.06em;
+}
+
+.spotlight-value {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  letter-spacing: 0.1em;
+}
+
+.spotlight-value.positive {
+  color: var(--success);
+}
+
+.spotlight-meter {
+  grid-column: 1 / -1;
+  height: 8px;
+  border-radius: 8px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(15, 23, 42, 0.7);
+  overflow: hidden;
+}
+
+.spotlight-meter span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.85), rgba(192, 132, 252, 0.85));
+  box-shadow: 0 10px 20px rgba(96, 165, 250, 0.35);
+}
+
+.spotlight-note {
+  margin: 0;
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  color: rgba(191, 219, 254, 0.7);
+}
+
+.hero-lab {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.hero-lab-intro {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+}
+
+.hero-lab-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.lab-card {
+  padding: 14px 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(96, 165, 250, 0.22);
+  background: linear-gradient(150deg, rgba(7, 12, 28, 0.88), rgba(24, 37, 64, 0.65));
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.55);
+}
+
+.lab-label {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(191, 219, 254, 0.62);
+}
+
+.lab-value {
+  margin: 0;
+  font-size: 16px;
+  letter-spacing: 0.08em;
+  color: var(--text-strong);
+}
+
+.lab-meta {
+  margin: 0;
+  font-size: 12px;
+  color: rgba(148, 163, 184, 0.8);
+  letter-spacing: 0.04em;
+}
+
+.metric-marquee {
+  margin-top: -4px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 12px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(96, 165, 250, 0.24);
+  background: linear-gradient(135deg, rgba(7, 12, 28, 0.82), rgba(18, 30, 60, 0.7));
+  box-shadow: 0 14px 32px rgba(5, 12, 30, 0.5);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+}
+
+.metric-marquee .marquee-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(12, 22, 44, 0.82);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.55);
+  font-family: var(--font-mono);
+}
+
+.metric-marquee strong {
+  color: var(--accent);
+  letter-spacing: 0.16em;
+}
+
+@media (max-width: 700px) {
+  .metric-marquee {
+    border-radius: 22px;
+  }
+}
+
 .title-group {
   display: flex;
   flex-direction: column;

--- a/baseball_sim/ui/static/css/layout.css
+++ b/baseball_sim/ui/static/css/layout.css
@@ -140,6 +140,143 @@
   line-height: 1.6;
 }
 
+.lobby-insight-panel {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 22px;
+  margin: 26px 0 18px;
+}
+
+.lobby-infobar {
+  flex: 1 1 360px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 14px;
+}
+
+.infobar-card {
+  position: relative;
+  padding: 18px 20px;
+  border-radius: 20px;
+  border: 1px solid rgba(125, 211, 252, 0.22);
+  background: linear-gradient(150deg, rgba(7, 12, 26, 0.82), rgba(20, 32, 62, 0.7));
+  box-shadow:
+    0 22px 44px rgba(5, 12, 30, 0.45),
+    inset 0 0 0 1px rgba(15, 23, 42, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow: hidden;
+}
+
+.infobar-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 18% 20%, rgba(96, 165, 250, 0.22), transparent 60%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.infobar-label {
+  margin: 0;
+  font-size: 12px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(191, 219, 254, 0.7);
+}
+
+.infobar-value {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 20px;
+  letter-spacing: 0.12em;
+  color: var(--text-strong);
+}
+
+.infobar-value.positive {
+  color: var(--success);
+}
+
+.infobar-value.highlight {
+  color: var(--accent);
+}
+
+.infobar-meta {
+  margin: 0;
+  font-size: 12px;
+  color: rgba(191, 219, 254, 0.72);
+  letter-spacing: 0.05em;
+}
+
+.infobar-spark {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  height: 48px;
+  padding-top: 4px;
+}
+
+.infobar-spark span {
+  flex: 1;
+  display: block;
+  height: var(--h);
+  border-radius: 6px 6px 2px 2px;
+  background: linear-gradient(180deg, rgba(96, 165, 250, 0.9), rgba(192, 132, 252, 0.55));
+  box-shadow: 0 12px 20px rgba(96, 165, 250, 0.32);
+}
+
+.lobby-highlights {
+  flex: 1 1 260px;
+  min-width: 240px;
+  padding: 20px 22px;
+  border-radius: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: linear-gradient(150deg, rgba(9, 14, 30, 0.86), rgba(30, 41, 83, 0.52));
+  box-shadow: 0 24px 48px rgba(5, 12, 30, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.lobby-highlights h3 {
+  margin: 0;
+  font-size: 15px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent-muted);
+}
+
+.lobby-highlights ul {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.lobby-highlights li {
+  position: relative;
+  padding-left: 18px;
+  font-size: 13px;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+}
+
+.lobby-highlights li::before {
+  content: '';
+  position: absolute;
+  left: 4px;
+  top: 8px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 12px rgba(96, 165, 250, 0.6);
+}
+
 .team-selection-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -1710,6 +1847,12 @@
 @media (max-width: 460px) {
   .action-card .action-buttons {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .lobby-insight-panel {
+    flex-direction: column;
   }
 }
 

--- a/baseball_sim/ui/templates/index.html
+++ b/baseball_sim/ui/templates/index.html
@@ -33,6 +33,102 @@
             </div>
           </div>
 
+          <div class="hero-grid" aria-label="ホーム画面ヒーロー">
+            <section class="hero-scoreboard" aria-labelledby="hero-scoreboard-title">
+              <header class="hero-scoreboard-header">
+                <p id="hero-scoreboard-title" class="scoreboard-label">LIVE MODEL PROJECTION</p>
+                <span class="scoreboard-clock">7回裏・1アウト・走者1,3塁</span>
+              </header>
+              <div class="scoreboard-body" role="presentation">
+                <div class="scoreboard-row is-away">
+                  <div class="scoreboard-team">
+                    <span class="team-abbr">AWY</span>
+                    <span class="team-name">Analytics Travelers</span>
+                  </div>
+                  <div class="scoreboard-score">
+                    <span class="runs">3</span>
+                    <span class="detail">OPS .742</span>
+                  </div>
+                </div>
+                <div class="scoreboard-row is-home">
+                  <div class="scoreboard-team">
+                    <span class="team-abbr">HME</span>
+                    <span class="team-name">Sabermetric Nine</span>
+                  </div>
+                  <div class="scoreboard-score">
+                    <span class="runs highlight">4</span>
+                    <span class="detail">wRC+ 126</span>
+                  </div>
+                </div>
+              </div>
+              <div class="scoreboard-trend" role="img" aria-label="最近5打席のWPAトレンド">
+                <span style="--p: 32%"></span>
+                <span style="--p: 64%"></span>
+                <span style="--p: 48%"></span>
+                <span style="--p: 78%"></span>
+                <span style="--p: 92%"></span>
+              </div>
+              <footer class="scoreboard-footer">
+                <div class="scoreboard-meta">
+                  <span class="meta-label">RISP指数</span>
+                  <span class="meta-value">1.34</span>
+                </div>
+                <div class="scoreboard-meta">
+                  <span class="meta-label">投球効率</span>
+                  <span class="meta-value">71%</span>
+                </div>
+                <div class="scoreboard-meta">
+                  <span class="meta-label">AI勝率</span>
+                  <span class="meta-value accent">68%</span>
+                </div>
+              </footer>
+            </section>
+
+            <section class="hero-spotlight" aria-labelledby="hero-spotlight-title">
+              <h3 id="hero-spotlight-title">データスポットライト</h3>
+              <ul class="spotlight-list">
+                <li>
+                  <span class="spotlight-label">xwOBA トレンド</span>
+                  <span class="spotlight-value positive">+0.027</span>
+                  <span class="spotlight-meter" aria-hidden="true"><span style="width: 68%"></span></span>
+                </li>
+                <li>
+                  <span class="spotlight-label">ホットゾーン捕球率</span>
+                  <span class="spotlight-value">78%</span>
+                  <span class="spotlight-meter" aria-hidden="true"><span style="width: 54%"></span></span>
+                </li>
+                <li>
+                  <span class="spotlight-label">次打者シミュ期待値</span>
+                  <span class="spotlight-value">0.62 run</span>
+                  <span class="spotlight-meter" aria-hidden="true"><span style="width: 82%"></span></span>
+                </li>
+              </ul>
+              <p class="spotlight-note">最新のサーベイメトリクスで試合の熱量を可視化しています。</p>
+            </section>
+
+            <section class="hero-lab" aria-labelledby="hero-lab-title">
+              <h3 id="hero-lab-title">Strategy Lab</h3>
+              <p class="hero-lab-intro">AIアシスタントが最適な采配とリスク対効果をリアルタイムに提案。</p>
+              <div class="hero-lab-grid">
+                <article class="lab-card">
+                  <p class="lab-label">推奨オーダー</p>
+                  <p class="lab-value">ダブルスチール 36%</p>
+                  <p class="lab-meta">成功時の勝率 +9pt</p>
+                </article>
+                <article class="lab-card">
+                  <p class="lab-label">投球プラン</p>
+                  <p class="lab-value">スプリット増 18%</p>
+                  <p class="lab-meta">被打率 0.211 予測</p>
+                </article>
+                <article class="lab-card">
+                  <p class="lab-label">守備シフト</p>
+                  <p class="lab-value">プル対策 D+</p>
+                  <p class="lab-meta">ISO -0.053</p>
+                </article>
+              </div>
+            </section>
+          </div>
+
           <div class="header-insights" id="insight-grid">
             <article class="insight-card" data-insight="inning-run-expectancy">
               <header class="insight-header">
@@ -101,6 +197,14 @@
             </article>
           </div>
 
+          <div class="metric-marquee" role="list" aria-label="データハイライト">
+            <span class="marquee-item" role="listitem"><strong>WPA</strong> +0.18 直前の二塁打</span>
+            <span class="marquee-item" role="listitem"><strong>CS%</strong> 38% 盗塁阻止の余地</span>
+            <span class="marquee-item" role="listitem"><strong>BABIP</strong> .284 &rarr; .301 過去10試合</span>
+            <span class="marquee-item" role="listitem"><strong>PitchMix</strong> 42% フォーシーム</span>
+            <span class="marquee-item" role="listitem"><strong>Clutch</strong> +1.2 今季累計</span>
+          </div>
+
           <div class="developer-hint">
             <small>💡 開発者向け: <kbd>Tab</kbd>キーでログパネルを表示/非表示</small>
           </div>
@@ -113,6 +217,39 @@
           <div class="title-card lobby-card">
             <h2>ホーム</h2>
             <p class="lobby-description">ようこそ。以下から選択してください。</p>
+            <div class="lobby-insight-panel" aria-label="ホーム分析">
+              <div class="lobby-infobar">
+                <article class="infobar-card">
+                  <p class="infobar-label">OPS トラッキング</p>
+                  <p class="infobar-value positive">+8.3%</p>
+                  <span class="infobar-spark" aria-hidden="true">
+                    <span style="--h: 22%"></span>
+                    <span style="--h: 48%"></span>
+                    <span style="--h: 62%"></span>
+                    <span style="--h: 86%"></span>
+                    <span style="--h: 68%"></span>
+                  </span>
+                </article>
+                <article class="infobar-card">
+                  <p class="infobar-label">投手WAR 残価</p>
+                  <p class="infobar-value">3.4</p>
+                  <p class="infobar-meta">次のローテ更新で+0.6予測</p>
+                </article>
+                <article class="infobar-card">
+                  <p class="infobar-label">守備効率</p>
+                  <p class="infobar-value highlight">92.1%</p>
+                  <p class="infobar-meta">リーグ平均 +4.8pt</p>
+                </article>
+              </div>
+              <div class="lobby-highlights">
+                <h3>今日のリサーチノート</h3>
+                <ul>
+                  <li>クラッチシナリオに合わせた代打候補を自動推薦。</li>
+                  <li>マイナー選手の成長曲線を可視化して昇格タイミングを提示。</li>
+                  <li>投手のリリースポイント差分をプロットして不調原因を診断。</li>
+                </ul>
+              </div>
+            </div>
             <div class="action-grid">
               <article class="action-card">
                 <div class="action-icon" aria-hidden="true">⚾</div>


### PR DESCRIPTION
## Summary
- Rebuild the home hero with a live projection scoreboard, data spotlight metrics, and strategy lab callouts tailored to sabermetric fans
- Add a marquee of key advanced stats plus lobby infobar and research notes to make the landing view feel like a data command center
- Style the new components with neon glassmorphism, responsive grids, and sparkline visual treatments for a premium analytics aesthetic

## Testing
- flask run --host=0.0.0.0 --port=5000

------
https://chatgpt.com/codex/tasks/task_e_68d78a2aabf48322b9a10e011a8da457