### PR TITLE
Add qualification indicators to simulation player tables

### DIFF
--- a/baseball_sim/ui/templates/index.html
+++ b/baseball_sim/ui/templates/index.html
@@ -463,6 +463,7 @@
                           <th>OBP</th>
                           <th>SLG</th>
                           <th>OPS</th>
+                          <th>規定到達</th>
                         </tr>
                       </thead>
                       <tbody id="simulation-selected-batting-body"></tbody>
@@ -486,6 +487,7 @@
                           <th>WHIP</th>
                           <th>K/9</th>
                           <th>BB/9</th>
+                          <th>規定到達</th>
                         </tr>
                       </thead>
                       <tbody id="simulation-selected-pitching-body"></tbody>


### PR DESCRIPTION
## Summary
- add a qualifying-status column to the simulation batting and pitching tables
- compute team-specific plate appearance and innings pitched thresholds for each player row
- show a fallback dash when no qualification threshold applies to the current team results

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d944bc20b48322ab343750e236cd48