### PR TITLE
Remove stray staticmethod placeholder in statistics module

### DIFF
--- a/baseball_sim/gameplay/statistics.py
+++ b/baseball_sim/gameplay/statistics.py
@@ -84,10 +84,7 @@ class StatsCalculator:
     def calculate_ops(obp, slg):
         """OPS計算（統一処理）"""
         return obp + slg
-    
-    @staticmethod
-    # Removed unused calculate_babip
-    
+
     @staticmethod
     def calculate_k_per_9(strikeouts, innings_pitched):
         """K/9計算（統一処理）"""


### PR DESCRIPTION
## Summary
- remove the stray `@staticmethod` placeholder next to the removed BABIP helper comment in `StatsCalculator`
- keep the remaining static method decorators aligned with their corresponding functions

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_68da20d350788322a579183529139d95