### PR TITLE
Fix rankings tab data extraction in simulation results

### DIFF
--- a/baseball_sim/ui/static/js/ui/renderers.js
+++ b/baseball_sim/ui/static/js/ui/renderers.js
@@ -4612,6 +4612,20 @@ function renderSimulationMatchupsTable(tbody, games, aliases) {
   });
 }
 
+function getNumericValue(source, ...keys) {
+  if (!source) return null;
+  for (let i = 0; i < keys.length; i += 1) {
+    const key = keys[i];
+    if (key && Object.prototype.hasOwnProperty.call(source, key)) {
+      const value = Number(source[key]);
+      if (Number.isFinite(value)) {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
 function buildBattingRankingRows(teams) {
   const rows = [];
   teams.forEach((team) => {
@@ -4623,25 +4637,24 @@ function buildBattingRankingRows(teams) {
     const batters = Array.isArray(team.batters) ? team.batters : [];
     batters.forEach((player) => {
       if (!player) return;
-      const paValue = Number(player.pa);
-      const pa = Number.isFinite(paValue) ? paValue : 0;
+      const pa = getNumericValue(player, 'pa', 'PA') ?? 0;
       const row = {
         name: player.name || '',
         team: teamName,
         pa,
-        ab: Number.isFinite(Number(player.ab)) ? Number(player.ab) : 0,
-        hits: Number.isFinite(Number(player.hits)) ? Number(player.hits) : 0,
-        homeRuns: Number.isFinite(Number(player.homeRuns)) ? Number(player.homeRuns) : 0,
-        runs: Number.isFinite(Number(player.runs)) ? Number(player.runs) : 0,
-        rbi: Number.isFinite(Number(player.rbi)) ? Number(player.rbi) : 0,
-        walks: Number.isFinite(Number(player.walks)) ? Number(player.walks) : 0,
-        strikeouts: Number.isFinite(Number(player.strikeouts)) ? Number(player.strikeouts) : 0,
-        avg: Number.isFinite(Number(player.avg)) ? Number(player.avg) : null,
-        obp: Number.isFinite(Number(player.obp)) ? Number(player.obp) : null,
-        slg: Number.isFinite(Number(player.slg)) ? Number(player.slg) : null,
-        ops: Number.isFinite(Number(player.ops)) ? Number(player.ops) : null,
-        k_pct: Number.isFinite(Number(player.k_pct)) ? Number(player.k_pct) : null,
-        bb_pct: Number.isFinite(Number(player.bb_pct)) ? Number(player.bb_pct) : null,
+        ab: getNumericValue(player, 'ab', 'AB') ?? 0,
+        hits: getNumericValue(player, 'hits', 'H') ?? 0,
+        homeRuns: getNumericValue(player, 'homeRuns', 'home_runs', 'HR') ?? 0,
+        runs: getNumericValue(player, 'runs', 'R') ?? 0,
+        rbi: getNumericValue(player, 'rbi', 'RBI') ?? 0,
+        walks: getNumericValue(player, 'walks', 'BB') ?? 0,
+        strikeouts: getNumericValue(player, 'strikeouts', 'SO', 'K') ?? 0,
+        avg: getNumericValue(player, 'avg') ?? null,
+        obp: getNumericValue(player, 'obp') ?? null,
+        slg: getNumericValue(player, 'slg') ?? null,
+        ops: getNumericValue(player, 'ops') ?? null,
+        k_pct: getNumericValue(player, 'k_pct', 'kPct') ?? null,
+        bb_pct: getNumericValue(player, 'bb_pct', 'bbPct') ?? null,
       };
       row.qualApplicable = qualificationApplicable;
       row.qualified = qualificationApplicable ? pa >= paRequirement : true;
@@ -4663,24 +4676,23 @@ function buildPitchingRankingRows(teams) {
     const pitchers = Array.isArray(team.pitchers) ? team.pitchers : [];
     pitchers.forEach((player) => {
       if (!player) return;
-      const ipValue = Number(player.ip);
-      const ip = Number.isFinite(ipValue) ? ipValue : 0;
+      const ip = getNumericValue(player, 'ip', 'IP') ?? 0;
       const outs = Math.round(ip * 3);
       const row = {
         name: player.name || '',
         team: teamName,
-        appearances: Number.isFinite(Number(player.appearances)) ? Number(player.appearances) : 0,
+        appearances: getNumericValue(player, 'appearances', 'G') ?? 0,
         ip,
-        hits: Number.isFinite(Number(player.hits)) ? Number(player.hits) : 0,
-        runs: Number.isFinite(Number(player.runs)) ? Number(player.runs) : 0,
-        earnedRuns: Number.isFinite(Number(player.earnedRuns)) ? Number(player.earnedRuns) : 0,
-        walks: Number.isFinite(Number(player.walks)) ? Number(player.walks) : 0,
-        strikeouts: Number.isFinite(Number(player.strikeouts)) ? Number(player.strikeouts) : 0,
-        homeRuns: Number.isFinite(Number(player.homeRuns)) ? Number(player.homeRuns) : 0,
-        era: Number.isFinite(Number(player.era)) ? Number(player.era) : null,
-        whip: Number.isFinite(Number(player.whip)) ? Number(player.whip) : null,
-        kPer9: Number.isFinite(Number(player.kPer9)) ? Number(player.kPer9) : null,
-        bbPer9: Number.isFinite(Number(player.bbPer9)) ? Number(player.bbPer9) : null,
+        hits: getNumericValue(player, 'hits', 'H') ?? 0,
+        runs: getNumericValue(player, 'runs', 'R') ?? 0,
+        earnedRuns: getNumericValue(player, 'earnedRuns', 'earned_runs', 'ER') ?? 0,
+        walks: getNumericValue(player, 'walks', 'BB') ?? 0,
+        strikeouts: getNumericValue(player, 'strikeouts', 'SO', 'K') ?? 0,
+        homeRuns: getNumericValue(player, 'homeRuns', 'home_runs', 'HR') ?? 0,
+        era: getNumericValue(player, 'era') ?? null,
+        whip: getNumericValue(player, 'whip') ?? null,
+        kPer9: getNumericValue(player, 'kPer9', 'k_per_9') ?? null,
+        bbPer9: getNumericValue(player, 'bbPer9', 'bb_per_9') ?? null,
       };
       row.qualApplicable = qualificationApplicable;
       row.qualified = qualificationApplicable ? outs >= ipRequirementOuts : true;


### PR DESCRIPTION
## Summary
- add a helper to read numeric stats regardless of camelCase or snake_case keys
- update batting and pitching ranking row builders to use the helper for all fields

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da5f0db324832297db4a7bf7acf056