### PR TITLE
Guard resetAbilityColor against missing elements

### DIFF
--- a/baseball_sim/ui/static/js/ui/renderers.js
+++ b/baseball_sim/ui/static/js/ui/renderers.js
@@ -260,13 +260,18 @@ function computeAbilityMetricStyling(metricKey, displayValue, { invert = false }
 }
 
 export function resetAbilityColor(element) {
+  if (!element || !element.classList || !element.style) {
+    return;
+  }
   element.classList.remove('ability-colorized');
-  element.style.removeProperty('--ability-color');
-  element.style.removeProperty('--ability-intensity');
-  element.style.removeProperty('color');
-  element.style.removeProperty('text-shadow');
-  element.style.removeProperty('font-weight');
-  delete element.dataset.abilityMetric;
+  element.style.removeProperty?.('--ability-color');
+  element.style.removeProperty?.('--ability-intensity');
+  element.style.removeProperty?.('color');
+  element.style.removeProperty?.('text-shadow');
+  element.style.removeProperty?.('font-weight');
+  if (element.dataset) {
+    delete element.dataset.abilityMetric;
+  }
 }
 
 export function applyAbilityColor(


### PR DESCRIPTION
## Summary
- avoid runtime errors by checking whether a node exposes classList/style before clearing ability color styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da692ed908832290fcec3ebedee11c