### PR TITLE
Fix simulation rankings tab visibility

### DIFF
--- a/baseball_sim/ui/templates/index.html
+++ b/baseball_sim/ui/templates/index.html
@@ -475,15 +475,15 @@
                 </div>
               </div>
               <div class="simulation-team-panels">
-              <section id="simulation-players-team-panel" class="simulation-team-panel">
-                <header class="simulation-team-header">
-                  <h3 id="simulation-selected-team-name">チーム</h3>
-                  <p id="simulation-selected-team-summary" class="simulation-team-summary"></p>
-                </header>
-                <div class="simulation-team-tables">
-                  <div class="simulation-player-table" id="simulation-selected-batting-table">
-                    <h4>打者成績</h4>
-                <table class="simulation-player-stats">
+                <section id="simulation-players-team-panel" class="simulation-team-panel">
+                  <header class="simulation-team-header">
+                    <h3 id="simulation-selected-team-name">チーム</h3>
+                    <p id="simulation-selected-team-summary" class="simulation-team-summary"></p>
+                  </header>
+                  <div class="simulation-team-tables">
+                    <div class="simulation-player-table" id="simulation-selected-batting-table">
+                      <h4>打者成績</h4>
+                      <table class="simulation-player-stats">
                   <thead>
                     <tr>
                           <th>選手</th>
@@ -537,6 +537,7 @@
                 </div>
               </section>
             </div>
+          </div>
             <div
               id="simulation-rankings-section"
               class="simulation-results-grid simulation-view-section hidden"


### PR DESCRIPTION
## Summary
- close the player results section before rendering the rankings block so the rankings tab is no longer hidden

## Testing
- not run (HTML template change only)

------
https://chatgpt.com/codex/tasks/task_e_68da7069832883228d3b7b64f8c3d756