### PR TITLE
Improve match mode selection layout

### DIFF
--- a/baseball_sim/ui/static/css/layout.css
+++ b/baseball_sim/ui/static/css/layout.css
@@ -239,53 +239,218 @@
 
 .match-mode-section {
   margin-top: 28px;
-  padding: 18px 20px;
-  border-radius: 18px;
+  padding: 22px clamp(18px, 4vw, 28px);
+  border-radius: 22px;
   border: 1px solid var(--border);
-  background: rgba(12, 22, 45, 0.68);
+  background: rgba(12, 22, 45, 0.72);
   display: grid;
-  gap: 16px;
+  gap: 20px;
+  position: relative;
+  overflow: hidden;
+}
+
+.match-mode-section::after {
+  content: '';
+  position: absolute;
+  inset: -40% 60% auto -20%;
+  height: 160px;
+  background: radial-gradient(circle at center, rgba(56, 189, 248, 0.18), transparent 70%);
+  pointer-events: none;
+  opacity: 0.55;
+}
+
+.match-mode-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px 18px;
+  position: relative;
+  z-index: 1;
 }
 
 .match-mode-label {
   margin: 0;
   font-size: 13px;
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   color: var(--text-muted);
 }
 
+.match-mode-subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+  max-width: 520px;
+  line-height: 1.6;
+}
+
 .match-mode-options {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  position: relative;
+  z-index: 1;
 }
 
 .match-mode-option {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 18px;
-  border-radius: 999px;
-  border: 1px solid rgba(125, 211, 252, 0.28);
-  background: rgba(10, 19, 40, 0.82);
-  color: var(--text);
-  cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
+  display: block;
+  color: inherit;
+  text-decoration: none;
 }
 
 .match-mode-option input {
-  accent-color: var(--accent);
+  position: absolute;
+  inset: 0;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  pointer-events: none;
 }
 
-.match-mode-option.active {
-  border-color: rgba(125, 211, 252, 0.55);
-  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.22);
-  background: rgba(14, 28, 56, 0.94);
+.match-mode-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px 20px;
+  border-radius: 18px;
+  border: 1px solid rgba(125, 211, 252, 0.28);
+  background: rgba(7, 14, 32, 0.88);
+  min-height: 148px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease,
+    background 0.2s ease;
 }
 
-.control-team-field select {
-  margin-top: 0;
+.match-mode-option:hover .match-mode-card,
+.match-mode-option:focus-within .match-mode-card {
+  border-color: rgba(125, 211, 252, 0.5);
+  background: rgba(12, 22, 45, 0.92);
+}
+
+.match-mode-option input:focus-visible + .match-mode-card {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(96, 165, 250, 0.35);
+}
+
+.match-mode-option input:checked + .match-mode-card {
+  border-color: rgba(125, 211, 252, 0.65);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.45);
+  background: rgba(16, 30, 58, 0.96);
+  transform: translateY(-2px);
+}
+
+.match-mode-title-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.match-mode-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  background: var(--accent-gradient-soft);
+  color: var(--accent-muted);
+  font-size: 22px;
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.match-mode-option input:checked + .match-mode-card .match-mode-icon {
+  background: var(--accent-gradient);
+  color: var(--text-strong);
+  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.4);
+}
+
+.match-mode-title {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.match-mode-description {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.7;
+}
+
+.match-mode-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0;
+}
+
+.match-mode-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(96, 165, 250, 0.14);
+  color: var(--accent-muted);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.match-mode-option input:checked + .match-mode-card .match-mode-chip {
+  background: rgba(96, 165, 250, 0.28);
+  color: var(--text);
+}
+
+.match-mode-control {
+  display: grid;
+  gap: 12px;
+  padding: 16px 18px 18px;
+  border-radius: 16px;
+  border: 1px solid rgba(125, 211, 252, 0.24);
+  background: rgba(6, 12, 26, 0.85);
+  position: relative;
+  z-index: 1;
+}
+
+.control-team-header {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.control-team-copy {
+  flex: 1;
+}
+
+.control-team-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  background: rgba(96, 165, 250, 0.15);
+  color: var(--accent-muted);
+  font-size: 18px;
+}
+
+.control-team-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.control-team-description {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.match-mode-control .team-select {
+  margin-top: 2px;
 }
 
 .team-selection-field label {

--- a/baseball_sim/ui/static/css/responsive.css
+++ b/baseball_sim/ui/static/css/responsive.css
@@ -1,5 +1,28 @@
 /* Responsive overrides */
 @media (max-width: 600px) {
+  .match-mode-section {
+    padding: 20px 16px;
+    border-radius: 18px;
+  }
+
+  .match-mode-section::after {
+    inset: auto -30% -40% 20%;
+    height: 140px;
+  }
+
+  .match-mode-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .match-mode-options {
+    grid-template-columns: 1fr;
+  }
+
+  .match-mode-card {
+    min-height: auto;
+  }
+
   .player-builder-layout {
     grid-template-columns: 1fr;
     gap: 16px;

--- a/baseball_sim/ui/templates/index.html
+++ b/baseball_sim/ui/templates/index.html
@@ -211,24 +211,83 @@
                 <select id="lobby-home-team" class="team-select"></select>
               </div>
             </div>
-            <div class="match-mode-section">
-              <p class="match-mode-label">試合モード</p>
+            <div
+              class="match-mode-section"
+              role="radiogroup"
+              aria-labelledby="match-mode-label"
+              aria-describedby="match-mode-help"
+            >
+              <div class="match-mode-header">
+                <p class="match-mode-label" id="match-mode-label">試合モード</p>
+                <p class="match-mode-subtitle" id="match-mode-help">
+                  プレイスタイルに合わせて操作方法を選択してください。
+                </p>
+              </div>
               <div class="match-mode-options">
                 <label class="match-mode-option">
                   <input type="radio" name="match-mode" value="manual" checked />
-                  <span>全操作対戦</span>
+                  <span class="match-mode-card">
+                    <span class="match-mode-title-row">
+                      <span class="match-mode-icon" aria-hidden="true">🕹️</span>
+                      <span class="match-mode-title">全操作対戦</span>
+                    </span>
+                    <p class="match-mode-description">
+                      攻守すべての采配をあなたが判断します。2人対戦や一括操作に最適です。
+                    </p>
+                    <div class="match-mode-meta" aria-hidden="true">
+                      <span class="match-mode-chip">両軍手動</span>
+                      <span class="match-mode-chip">細かな采配</span>
+                    </div>
+                  </span>
                 </label>
                 <label class="match-mode-option">
                   <input type="radio" name="match-mode" value="cpu" />
-                  <span>CPU対戦</span>
+                  <span class="match-mode-card">
+                    <span class="match-mode-title-row">
+                      <span class="match-mode-icon" aria-hidden="true">🤝</span>
+                      <span class="match-mode-title">CPU対戦</span>
+                    </span>
+                    <p class="match-mode-description">
+                      片方のチームだけを自分で操作し、もう一方はCPUが采配します。
+                    </p>
+                    <div class="match-mode-meta" aria-hidden="true">
+                      <span class="match-mode-chip">片側操作</span>
+                      <span class="match-mode-chip">CPUサポート</span>
+                    </div>
+                  </span>
                 </label>
                 <label class="match-mode-option">
                   <input type="radio" name="match-mode" value="auto" />
-                  <span>全自動CPU</span>
+                  <span class="match-mode-card">
+                    <span class="match-mode-title-row">
+                      <span class="match-mode-icon" aria-hidden="true">🛰️</span>
+                      <span class="match-mode-title">全自動CPU</span>
+                    </span>
+                    <p class="match-mode-description">
+                      両チームの采配をCPUに任せて観戦するモードです。リプレイ検証に最適。
+                    </p>
+                    <div class="match-mode-meta" aria-hidden="true">
+                      <span class="match-mode-chip">観戦モード</span>
+                      <span class="match-mode-chip">オート進行</span>
+                    </div>
+                  </span>
                 </label>
               </div>
-              <div class="team-selection-field control-team-field hidden" id="control-team-field">
-                <label for="control-team-select">自操作チーム</label>
+              <div
+                class="match-mode-control control-team-field hidden"
+                id="control-team-field"
+                aria-hidden="true"
+              >
+                <div class="control-team-header">
+                  <span class="control-team-icon" aria-hidden="true">🎮</span>
+                  <div class="control-team-copy">
+                    <p class="control-team-title">操作するチーム</p>
+                    <p class="control-team-description">
+                      CPU対戦を選んだ場合に、あなたが采配する側を指定します。
+                    </p>
+                  </div>
+                </div>
+                <label class="visually-hidden" for="control-team-select">自操作チーム</label>
                 <select id="control-team-select" class="team-select">
                   <option value="home">ホーム</option>
                   <option value="away">アウェイ</option>
@@ -685,24 +744,83 @@
               </div>
             </div>
 
-            <div class="match-mode-section">
-              <p class="match-mode-label">試合モード</p>
+            <div
+              class="match-mode-section"
+              role="radiogroup"
+              aria-labelledby="simulation-match-mode-label"
+              aria-describedby="simulation-match-mode-help"
+            >
+              <div class="match-mode-header">
+                <p class="match-mode-label" id="simulation-match-mode-label">試合モード</p>
+                <p class="match-mode-subtitle" id="simulation-match-mode-help">
+                  シミュレーション結果をどう操作するかを選択します。
+                </p>
+              </div>
               <div class="match-mode-options">
                 <label class="match-mode-option">
                   <input type="radio" name="simulation-match-mode" value="manual" checked />
-                  <span>全操作対戦</span>
+                  <span class="match-mode-card">
+                    <span class="match-mode-title-row">
+                      <span class="match-mode-icon" aria-hidden="true">🕹️</span>
+                      <span class="match-mode-title">全操作対戦</span>
+                    </span>
+                    <p class="match-mode-description">
+                      すべての采配を自分で行うモードです。結果の裏付けをプレイで体感できます。
+                    </p>
+                    <div class="match-mode-meta" aria-hidden="true">
+                      <span class="match-mode-chip">両軍手動</span>
+                      <span class="match-mode-chip">練習向け</span>
+                    </div>
+                  </span>
                 </label>
                 <label class="match-mode-option">
                   <input type="radio" name="simulation-match-mode" value="cpu" />
-                  <span>CPU対戦</span>
+                  <span class="match-mode-card">
+                    <span class="match-mode-title-row">
+                      <span class="match-mode-icon" aria-hidden="true">🤝</span>
+                      <span class="match-mode-title">CPU対戦</span>
+                    </span>
+                    <p class="match-mode-description">
+                      CPUに片側を任せつつ、自分の采配でシミュレーション結果を再検証します。
+                    </p>
+                    <div class="match-mode-meta" aria-hidden="true">
+                      <span class="match-mode-chip">片側操作</span>
+                      <span class="match-mode-chip">CPUサポート</span>
+                    </div>
+                  </span>
                 </label>
                 <label class="match-mode-option">
                   <input type="radio" name="simulation-match-mode" value="auto" />
-                  <span>全自動CPU</span>
+                  <span class="match-mode-card">
+                    <span class="match-mode-title-row">
+                      <span class="match-mode-icon" aria-hidden="true">🛰️</span>
+                      <span class="match-mode-title">全自動CPU</span>
+                    </span>
+                    <p class="match-mode-description">
+                      収集したデータを完全自動で再現します。観戦しながら結果を比較できます。
+                    </p>
+                    <div class="match-mode-meta" aria-hidden="true">
+                      <span class="match-mode-chip">観戦モード</span>
+                      <span class="match-mode-chip">オート進行</span>
+                    </div>
+                  </span>
                 </label>
               </div>
-              <div class="team-selection-field control-team-field hidden" id="simulation-match-control-field">
-                <label for="simulation-match-control-team">自操作チーム</label>
+              <div
+                class="match-mode-control control-team-field hidden"
+                id="simulation-match-control-field"
+                aria-hidden="true"
+              >
+                <div class="control-team-header">
+                  <span class="control-team-icon" aria-hidden="true">🎮</span>
+                  <div class="control-team-copy">
+                    <p class="control-team-title">操作するチーム</p>
+                    <p class="control-team-description">
+                      CPU対戦では、どちらのチームを手動で操作するかを指定できます。
+                    </p>
+                  </div>
+                </div>
+                <label class="visually-hidden" for="simulation-match-control-team">自操作チーム</label>
                 <select id="simulation-match-control-team" class="team-select">
                   <option value="home">ホーム</option>
                   <option value="away">アウェイ</option>


### PR DESCRIPTION
## Summary
- redesigned the match mode picker in the team selection flow with descriptive cards, icons, and accessibility metadata for better visibility
- introduced a dedicated control-team panel that clarifies CPU match responsibilities while keeping the existing styling language
- refreshed styling tokens for match mode elements and added responsive tweaks so the layout scales cleanly on narrow screens

## Testing
- not run (environment lacks required Python packages and installing them fails behind the proxy)


------
https://chatgpt.com/codex/tasks/task_e_68da8afd40ec8322b8cf5c44a799efee