### PR TITLE
Stop generating simulation result files during simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ requirements.txt は最小構成（Flask のみ）です。予測モデルや学
 
 ## シミュレーションの一括実行（スクリプトから）
 - 例: `python -c "from baseball_sim.interface.simulation import simulate_games; simulate_games(num_games=20)"`
-- 結果は `simulation_results/` 配下に保存されます。
+- 結果は戻り値として返されるため、必要に応じて任意の形式で保存してください。
 - リーグ戦モード: `simulate_games(league_options={"teams": [...], "games_per_card": 3, "cards_per_opponent": 2})`
   - `teams` には `player_data/teams.json` と同形式の辞書をリストで渡します（同一チームを複数回指定可能）。
   - チーム数は偶数である必要があります。1カードあたりの試合数（c）、カードの繰り返し回数（d）を設定すると、

--- a/baseball_sim/config/constants.py
+++ b/baseball_sim/config/constants.py
@@ -116,7 +116,6 @@ class FilePaths:
     MODELS_DIR = "prediction_models/models"
     BATTING_MODEL = "batting_model.joblib"
     NN_MODEL = "trained_model_NN.pth"
-    DEFAULT_SIMULATION_OUTPUT = "simulation_results.txt"
     TEAM_LIBRARY_DIR = "teams"
     TEAM_SELECTION_JSON = "team_selection.json"
 


### PR DESCRIPTION
## Summary
- remove the simulation result file writer and stop collecting data that was only used for file export
- update the README to explain that callers receive results via return values instead of disk output
- clean up the unused default simulation output constant

## Testing
- python -m compileall baseball_sim/interface/simulation.py

------
https://chatgpt.com/codex/tasks/task_e_68dd4c660f0483228c31fe06f4111073