### PR TITLE
Ensure auto matches run live analytics

### DIFF
--- a/baseball_sim/interface/live_analytics.py
+++ b/baseball_sim/interface/live_analytics.py
@@ -1,0 +1,308 @@
+"""Helpers to evaluate live in-game analytics via CPU simulations."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+from baseball_sim.config import GameResults
+from baseball_sim.gameplay.cpu_strategy import (
+    CPUOffenseDecision,
+    CPUPlayType,
+    plan_defensive_substitutions,
+    plan_pinch_hit,
+    plan_pinch_run,
+    plan_pitcher_change,
+    select_offense_play,
+)
+from baseball_sim.gameplay.substitutions import SubstitutionManager
+
+
+@dataclass
+class LiveAnalyticsResult:
+    """Container for aggregated simulation metrics."""
+
+    offense_key: Optional[str]
+    samples: int
+    expected_runs: float
+    score_probability: float
+    home_win_probability: float
+    home_wins: int
+    away_wins: int
+    ties: int
+
+    def as_payload(self) -> Dict[str, object]:
+        return {
+            "offense": self.offense_key,
+            "samples": self.samples,
+            "result": {
+                "expected_runs": self.expected_runs,
+                "score_probability": self.score_probability,
+                "home_win_probability": self.home_win_probability,
+                "home_wins": self.home_wins,
+                "away_wins": self.away_wins,
+                "ties": self.ties,
+            },
+        }
+
+
+def simulate_live_analytics(game_state, samples: int = 100) -> LiveAnalyticsResult:
+    """Run repeated CPU simulations from ``game_state`` and aggregate metrics."""
+
+    if samples <= 0:
+        samples = 1
+
+    base_state = game_state
+    if getattr(base_state, "game_ended", False):
+        offense_key = _resolve_offense_key(base_state)
+        winner = _determine_winner(base_state)
+        home_win_probability = 1.0 if winner == "home" else 0.0
+        if winner is None:
+            home_win_probability = 0.5
+        return LiveAnalyticsResult(
+            offense_key=offense_key,
+            samples=1,
+            expected_runs=0.0,
+            score_probability=0.0,
+            home_win_probability=home_win_probability,
+            home_wins=1 if winner == "home" else 0,
+            away_wins=1 if winner == "away" else 0,
+            ties=1 if winner is None else 0,
+        )
+
+    offense_key = _resolve_offense_key(base_state)
+    base_home = getattr(base_state, "home_score", 0)
+    base_away = getattr(base_state, "away_score", 0)
+
+    total_runs = 0.0
+    scoring_games = 0
+    home_wins = 0
+    away_wins = 0
+    ties = 0
+
+    for _ in range(samples):
+        clone = deepcopy(base_state)
+        _play_out_game(clone)
+
+        final_home = getattr(clone, "home_score", base_home)
+        final_away = getattr(clone, "away_score", base_away)
+
+        offense_runs = (final_home - base_home) if offense_key == "home" else (final_away - base_away)
+        if offense_runs > 0:
+            scoring_games += 1
+        total_runs += offense_runs
+
+        winner = _determine_winner(clone)
+        if winner == "home":
+            home_wins += 1
+        elif winner == "away":
+            away_wins += 1
+        else:
+            ties += 1
+
+    expected_runs = total_runs / samples
+    score_probability = scoring_games / samples
+    home_win_probability = (home_wins + 0.5 * ties) / samples
+
+    return LiveAnalyticsResult(
+        offense_key=offense_key,
+        samples=samples,
+        expected_runs=expected_runs,
+        score_probability=score_probability,
+        home_win_probability=home_win_probability,
+        home_wins=home_wins,
+        away_wins=away_wins,
+        ties=ties,
+    )
+
+
+def _resolve_offense_key(game_state) -> Optional[str]:
+    if game_state is None:
+        return None
+    if getattr(game_state, "batting_team", None) is getattr(game_state, "home_team", None):
+        return "home"
+    if getattr(game_state, "batting_team", None) is getattr(game_state, "away_team", None):
+        return "away"
+    return None
+
+
+def _determine_winner(game_state) -> Optional[str]:
+    home = getattr(game_state, "home_score", 0)
+    away = getattr(game_state, "away_score", 0)
+    if home > away:
+        return "home"
+    if away > home:
+        return "away"
+    return None
+
+
+def _play_out_game(game_state) -> None:
+    """Advance ``game_state`` to completion with CPU strategies."""
+
+    offense_context: Dict[str, Tuple[Optional[int], int, bool, int, Tuple[int, int, int]]] = {}
+    defense_context: Dict[str, Tuple[Optional[int], int, bool, int, Tuple[int, int, int]]] = {}
+
+    while not getattr(game_state, "game_ended", False):
+        offense_team = getattr(game_state, "batting_team", None)
+        defense_team = getattr(game_state, "fielding_team", None)
+        if offense_team is None or defense_team is None:
+            break
+
+        offense_key = _resolve_offense_key(game_state)
+        defense_key = "home" if offense_key == "away" else "away"
+
+        if defense_key:
+            _apply_defense_strategy(game_state, defense_team, defense_key, defense_context)
+        if offense_key:
+            _apply_offense_strategy(game_state, offense_team, offense_key, offense_context)
+
+        substitution_manager = SubstitutionManager(offense_team)
+        try:
+            pinch_plan = plan_pinch_hit(game_state, offense_team, substitution_manager)
+        except Exception:
+            pinch_plan = None
+        if pinch_plan:
+            bench = substitution_manager.get_available_bench_players()
+            if 0 <= pinch_plan.bench_index < len(bench):
+                substitution_manager.execute_pinch_hit(pinch_plan.bench_index, pinch_plan.lineup_index)
+
+        batter = getattr(offense_team, "current_batter", None)
+        pitcher = getattr(defense_team, "current_pitcher", None)
+        if batter is None or pitcher is None:
+            break
+
+        decision = select_offense_play(game_state, offense_team)
+        play = decision.play if isinstance(decision, CPUOffenseDecision) else CPUPlayType.SWING
+
+        prev_inning = game_state.inning
+        prev_half_top = game_state.is_top_inning
+
+        while True:
+            if play is CPUPlayType.STEAL:
+                if not game_state.can_steal():
+                    play = CPUPlayType.SWING
+                    continue
+                steal_info = game_state.execute_steal()
+                result_key = steal_info.get("result") if isinstance(steal_info, dict) else None
+                if result_key == GameResults.STEAL_NOT_ALLOWED:
+                    play = CPUPlayType.SWING
+                    continue
+                # Steal attempt completed; advance to next situation.
+                break
+
+            if play is CPUPlayType.SQUEEZE:
+                if not game_state.can_squeeze():
+                    play = CPUPlayType.SWING
+                    continue
+                game_state.execute_squeeze(batter, pitcher)
+                pitcher.decrease_stamina()
+                break
+
+            if play is CPUPlayType.BUNT:
+                if not game_state.can_bunt():
+                    play = CPUPlayType.SWING
+                    continue
+                game_state.execute_bunt(batter, pitcher)
+                pitcher.decrease_stamina()
+                break
+
+            # Default swing
+            result = game_state.calculate_result(batter, pitcher)
+            game_state.apply_result(result, batter)
+            pitcher.decrease_stamina()
+            break
+
+        if getattr(game_state, "game_ended", False):
+            break
+
+        inning_changed = (prev_inning != game_state.inning) or (prev_half_top != game_state.is_top_inning)
+        if play is not CPUPlayType.STEAL and not inning_changed:
+            offense_team.next_batter()
+
+
+def _build_strategy_context(game_state) -> Tuple[Optional[int], int, bool, int, Tuple[int, int, int]]:
+    last_sequence = None
+    last_play = getattr(game_state, "last_play", None)
+    if isinstance(last_play, dict):
+        last_sequence = last_play.get("sequence")
+        if last_sequence is not None:
+            try:
+                last_sequence = int(last_sequence)
+            except (TypeError, ValueError):
+                last_sequence = None
+    base_signature = tuple(1 if base is not None else 0 for base in game_state.bases[:3])
+    return (last_sequence, game_state.inning, game_state.is_top_inning, game_state.outs, base_signature)
+
+
+def _apply_offense_strategy(game_state, offense_team, offense_key, context_store) -> None:
+    context = _build_strategy_context(game_state)
+    if context_store.get(offense_key) == context:
+        return
+    context_store[offense_key] = context
+
+    substitution_manager = SubstitutionManager(offense_team)
+    try:
+        plan = plan_pinch_run(game_state, offense_team, substitution_manager)
+    except Exception:
+        plan = None
+    if not plan:
+        return
+
+    bench = substitution_manager.get_available_bench_players()
+    if not (0 <= plan.bench_index < len(bench)):
+        return
+
+    success, _ = substitution_manager.execute_defensive_substitution(plan.bench_index, plan.lineup_index)
+    if not success:
+        return
+
+    lineup = getattr(offense_team, "lineup", [])
+    if 0 <= plan.lineup_index < len(lineup) and plan.base_index < len(game_state.bases):
+        game_state.bases[plan.base_index] = lineup[plan.lineup_index]
+
+
+def _apply_defense_strategy(game_state, defense_team, defense_key, context_store) -> None:
+    context = _build_strategy_context(game_state)
+    if context_store.get(defense_key) == context:
+        return
+    context_store[defense_key] = context
+
+    substitution_manager = SubstitutionManager(defense_team)
+    plan = plan_pitcher_change(game_state, defense_team, substitution_manager)
+    if plan:
+        success, _ = substitution_manager.execute_pitcher_change(plan.pitcher_index)
+        if success:
+            _evaluate_alignment(game_state)
+        return
+
+    try:
+        def_plans = plan_defensive_substitutions(game_state, defense_team, substitution_manager)
+    except Exception:
+        def_plans = []
+
+    applied = False
+    for dplan in def_plans:
+        bench = substitution_manager.get_available_bench_players()
+        bench_index = None
+        if dplan.bench_player in bench:
+            bench_index = bench.index(dplan.bench_player)
+        else:
+            for idx, player in enumerate(bench):
+                if getattr(player, "name", None) == getattr(dplan, "incoming_name", None):
+                    bench_index = idx
+                    break
+        if bench_index is None:
+            continue
+        success, _ = substitution_manager.execute_defensive_substitution(bench_index, dplan.lineup_index)
+        if success:
+            applied = True
+
+    if applied:
+        _evaluate_alignment(game_state)
+
+
+def _evaluate_alignment(game_state) -> None:
+    evaluator = getattr(game_state, "_evaluate_defensive_alignment", None)
+    if callable(evaluator):
+        evaluator()

--- a/baseball_sim/ui/gameplay_actions.py
+++ b/baseball_sim/ui/gameplay_actions.py
@@ -93,6 +93,9 @@ class GameplayActionsMixin:
             return self.build_state()
 
         self._action_block_reason = None
+        invalidate = getattr(self, "_invalidate_live_analytics", None)
+        if callable(invalidate):
+            invalidate()
 
         batter = self.game_state.batting_team.current_batter
         pitcher = self.game_state.fielding_team.current_pitcher
@@ -157,6 +160,9 @@ class GameplayActionsMixin:
             return self.build_state()
 
         self._action_block_reason = None
+        invalidate = getattr(self, "_invalidate_live_analytics", None)
+        if callable(invalidate):
+            invalidate()
 
         batter = self.game_state.batting_team.current_batter
         pitcher = self.game_state.fielding_team.current_pitcher
@@ -233,6 +239,9 @@ class GameplayActionsMixin:
             return self.build_state()
 
         self._action_block_reason = None
+        invalidate = getattr(self, "_invalidate_live_analytics", None)
+        if callable(invalidate):
+            invalidate()
 
         batter = self.game_state.batting_team.current_batter
         pitcher = self.game_state.fielding_team.current_pitcher
@@ -307,6 +316,9 @@ class GameplayActionsMixin:
             return self.build_state()
 
         self._action_block_reason = None
+        invalidate = getattr(self, "_invalidate_live_analytics", None)
+        if callable(invalidate):
+            invalidate()
 
         prev_inning = self.game_state.inning
         prev_half = self.game_state.is_top_inning
@@ -361,6 +373,10 @@ class GameplayActionsMixin:
                 self._overlays.publish("pinch_hit", message)
             except Exception:
                 pass
+        if success:
+            invalidate = getattr(self, "_invalidate_live_analytics", None)
+            if callable(invalidate):
+                invalidate()
         return self.build_state()
 
     def execute_pinch_run(self, base_index: int, bench_index: int) -> Dict[str, Any]:
@@ -407,6 +423,9 @@ class GameplayActionsMixin:
             message = (
                 f"{new_runner.name} pinch runs for {original_name} on {label}. {result_message}"
             )
+            invalidate = getattr(self, "_invalidate_live_analytics", None)
+            if callable(invalidate):
+                invalidate()
 
         self._notifications.publish("success" if success else "danger", message)
         variant = "highlight" if success else "danger"
@@ -452,6 +471,9 @@ class GameplayActionsMixin:
         variant = "highlight" if success else "danger"
         self._log.append(message, variant=variant)
         if success:
+            invalidate = getattr(self, "_invalidate_live_analytics", None)
+            if callable(invalidate):
+                invalidate()
             self._refresh_defense_status()
             if hasattr(self, "_overlays"):
                 try:
@@ -477,6 +499,9 @@ class GameplayActionsMixin:
         variant = "highlight" if success else "danger"
         self._log.append(message, variant=variant)
         if success:
+            invalidate = getattr(self, "_invalidate_live_analytics", None)
+            if callable(invalidate):
+                invalidate()
             self._refresh_defense_status()
             if hasattr(self, "_overlays"):
                 try:
@@ -508,6 +533,9 @@ class GameplayActionsMixin:
             return self.build_state()
 
         self._action_block_reason = None
+        invalidate = getattr(self, "_invalidate_live_analytics", None)
+        if callable(invalidate):
+            invalidate()
 
         offense_key = "home" if self.game_state.batting_team is self.home_team else "away"
         if getattr(self, "_control_mode", "manual") == "auto":

--- a/baseball_sim/ui/routes.py
+++ b/baseball_sim/ui/routes.py
@@ -117,6 +117,16 @@ def create_routes(session: WebGameSession) -> Blueprint:
             return create_error_response(str(exc), session)
         return jsonify(state)
 
+    @api_bp.post("/game/analytics")
+    def compute_analytics() -> Dict[str, Any]:
+        payload = request.get_json(silent=True) or {}
+        samples = parse_int_param(payload, "samples", 100)
+        try:
+            state = session.compute_live_analytics(samples)
+        except GameSessionError as exc:
+            return create_error_response(str(exc), session)
+        return jsonify(state)
+
     @api_bp.post("/strategy/steal")
     def steal() -> Dict[str, Any]:
         try:

--- a/baseball_sim/ui/state_builders.py
+++ b/baseball_sim/ui/state_builders.py
@@ -177,6 +177,13 @@ class SessionStateBuilder:
             except Exception:
                 control_state = {}
 
+        analytics_state: Dict[str, object] = {}
+        if hasattr(self._session, "get_analytics_state"):
+            try:
+                analytics_state = self._session.get_analytics_state()
+            except Exception:
+                analytics_state = {}
+
         game_state = self._session.game_state
         if not game_state:
             return (
@@ -194,6 +201,7 @@ class SessionStateBuilder:
                     "max_innings": 9,
                     "control": control_state,
                     "overlays": [],
+                    "analytics": analytics_state,
                 },
                 action_block_reason,
             )
@@ -364,6 +372,7 @@ class SessionStateBuilder:
                 },
                 "overlays": list(overlays or []),
                 "control": control_state,
+                "analytics": analytics_state,
             },
             action_block_reason,
         )

--- a/baseball_sim/ui/static/css/base.css
+++ b/baseball_sim/ui/static/css/base.css
@@ -140,6 +140,17 @@ a:focus-visible {
   z-index: 1;
 }
 
+.app-shell.analytics-pending {
+  cursor: progress;
+}
+
+.app-shell.analytics-pending button,
+.app-shell.analytics-pending [role='button'],
+.app-shell.analytics-pending .action-card,
+.app-shell.analytics-pending .insight-card {
+  cursor: progress;
+}
+
 .app-header {
   position: relative;
   padding: 36px clamp(24px, 6vw, 60px) 32px;

--- a/baseball_sim/ui/static/css/game.css
+++ b/baseball_sim/ui/static/css/game.css
@@ -186,6 +186,50 @@
   background: rgba(96, 165, 250, 0.32);
 }
 
+.screen.analytics-lock {
+  position: relative;
+}
+
+.screen.analytics-lock::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.85), rgba(30, 41, 59, 0.78));
+  backdrop-filter: blur(2px);
+  opacity: 0.9;
+  border-radius: 24px;
+  z-index: 200;
+  pointer-events: auto;
+}
+
+.screen.analytics-lock::after {
+  content: 'CPU解析中…';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 18px 32px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(15, 23, 42, 0.92);
+  color: var(--text-strong);
+  font-family: var(--font-heading);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.95rem;
+  box-shadow: 0 28px 48px rgba(2, 6, 23, 0.45);
+  z-index: 201;
+  pointer-events: none;
+}
+
+.screen.analytics-lock > * {
+  pointer-events: none;
+  user-select: none;
+  filter: blur(1px);
+  opacity: 0.6;
+  transition: filter 0.2s ease, opacity 0.2s ease;
+}
+
 .situation-panel {
   display: flex;
   align-items: center;

--- a/baseball_sim/ui/static/js/config.js
+++ b/baseball_sim/ui/static/js/config.js
@@ -11,6 +11,7 @@ export const CONFIG = {
       gameBunt: '/api/game/bunt',
       gameSqueeze: '/api/game/squeeze',
       gameProgress: '/api/game/progress',
+      gameAnalytics: '/api/game/analytics',
       strategySteal: '/api/strategy/steal',
       pinchHit: '/api/strategy/pinch_hit',
       pinchRun: '/api/strategy/pinch_run',

--- a/baseball_sim/ui/static/js/dom.js
+++ b/baseball_sim/ui/static/js/dom.js
@@ -1,6 +1,7 @@
 // Centralised DOM element references used throughout the UI.
 
 export const elements = {
+  appShell: document.querySelector('.app-shell'),
   lobbyScreen: document.getElementById('lobby-screen'),
   teamSelectScreen: document.getElementById('team-select-screen'),
   titleScreen: document.getElementById('title-screen'),

--- a/baseball_sim/ui/static/js/state.js
+++ b/baseball_sim/ui/static/js/state.js
@@ -13,6 +13,8 @@ export const stateCache = {
   abilitiesView: { team: 'away', type: 'batting' },
   uiView: 'lobby',
   titlePitcherReview: { team: null, pitcher: null },
+  analytics: { running: false, samples: 0, sequence: null, offense: null, result: null, timestamp: null },
+  analyticsPending: false,
   // Navigation-reset flags
   resetTeamSelect: false,
   resetSimulationSelect: false,

--- a/baseball_sim/ui/team_management.py
+++ b/baseball_sim/ui/team_management.py
@@ -77,6 +77,9 @@ class TeamManagementMixin:
             raise GameSessionError("Teams could not be loaded from the data files.")
 
         self.game_state = GameState(self.home_team, self.away_team)
+        reset_analytics = getattr(self, "_reset_live_analytics", None)
+        if callable(reset_analytics):
+            reset_analytics()
         self._log.clear()
         self._game_over_announced = False
         self._action_block_reason = None
@@ -147,6 +150,9 @@ class TeamManagementMixin:
         """Exit the current game and return to the title screen."""
 
         self.game_state = None
+        reset_analytics = getattr(self, "_reset_live_analytics", None)
+        if callable(reset_analytics):
+            reset_analytics()
         self._game_over_announced = False
         self._action_block_reason = None
         self._notifications.publish("info", "Game closed. Return to title screen.")
@@ -169,6 +175,9 @@ class TeamManagementMixin:
         self._action_block_reason = None
         self._notifications.publish("info", "Team data reloaded.")
         self._clear_simulation_results()
+        reset_analytics = getattr(self, "_reset_live_analytics", None)
+        if callable(reset_analytics):
+            reset_analytics()
         return self.build_state()
 
     def _resolve_team_key(self, team_key: str) -> Tuple[object, str]:


### PR DESCRIPTION
## Summary
- replace the heuristic insights with a backend Monte Carlo simulator and expose a `/api/game/analytics` endpoint
- keep the session state in sync with analytics progress, blocking user actions while CPU games run
- wire the frontend to fetch analytics after each action and lock the UI with a pending overlay until the new metrics arrive
- trigger the live analytics replay for every match control mode while leaving simulation screens idle

## Testing
- pytest *(fails: missing optional dependencies `joblib` and `torch`)*

------
https://chatgpt.com/codex/tasks/task_e_68dd55f34810832289f5fc908638ce5b