### PR TITLE
Refactor simulation interface into modular league coordinator

### DIFF
--- a/baseball_sim/interface/game_management.py
+++ b/baseball_sim/interface/game_management.py
@@ -1,0 +1,130 @@
+"""Helpers for preparing teams and tracking results between games."""
+
+from __future__ import annotations
+
+def reset_team_and_players(
+    home_team,
+    away_team,
+    *,
+    home_pitcher_pool=None,
+    away_pitcher_pool=None,
+    home_starting_pitcher=None,
+    away_starting_pitcher=None,
+):
+    """Reset team/player state between games in a series."""
+
+    for team in (home_team, away_team):
+        if hasattr(team, "ejected_players"):
+            team.ejected_players = []
+        try:
+            init_lineup = list(getattr(team, "_initial_lineup", []) or [])
+            init_positions = list(getattr(team, "_initial_lineup_positions", []) or [])
+            init_bench = list(getattr(team, "_initial_bench", []) or [])
+
+            if init_lineup and init_positions and len(init_lineup) == len(init_positions):
+                team.lineup = list(init_lineup)
+                if hasattr(team, "defensive_positions"):
+                    for key in list(team.defensive_positions.keys()):
+                        team.defensive_positions[key] = None
+                for player, pos in zip(init_lineup, init_positions):
+                    if pos is not None:
+                        player.current_position = pos
+                        if hasattr(team, "defensive_positions"):
+                            team.defensive_positions[pos] = player
+                team.bench = list(init_bench)
+        except Exception:
+            pass
+
+    if home_pitcher_pool is not None:
+        home_team.pitchers = list(home_pitcher_pool)
+    if away_pitcher_pool is not None:
+        away_team.pitchers = list(away_pitcher_pool)
+
+    if hasattr(home_team, "pitcher_rotation"):
+        home_team.pitcher_rotation = [
+            pitcher for pitcher in home_team.pitcher_rotation if pitcher in home_team.pitchers
+        ]
+    if hasattr(away_team, "pitcher_rotation"):
+        away_team.pitcher_rotation = [
+            pitcher for pitcher in away_team.pitcher_rotation if pitcher in away_team.pitchers
+        ]
+
+    for pitcher in home_team.pitchers:
+        ptype = getattr(pitcher, "pitcher_type", "").upper()
+        if ptype == "RP":
+            current = getattr(pitcher, "current_stamina", pitcher.stamina)
+            pitcher.current_stamina = min(pitcher.stamina, current + 10)
+        else:
+            pitcher.current_stamina = pitcher.stamina
+
+    for pitcher in away_team.pitchers:
+        ptype = getattr(pitcher, "pitcher_type", "").upper()
+        if ptype == "RP":
+            current = getattr(pitcher, "current_stamina", pitcher.stamina)
+            pitcher.current_stamina = min(pitcher.stamina, current + 10)
+        else:
+            pitcher.current_stamina = pitcher.stamina
+
+    home_team.current_batter_index = 0
+    away_team.current_batter_index = 0
+
+    home_team.current_pitcher = (
+        home_starting_pitcher
+        if home_starting_pitcher is not None
+        else (home_team.pitchers[0] if home_team.pitchers else None)
+    )
+    away_team.current_pitcher = (
+        away_starting_pitcher
+        if away_starting_pitcher is not None
+        else (away_team.pitchers[0] if away_team.pitchers else None)
+    )
+
+
+def update_statistics(results, game, game_result):
+    """Update aggregated team statistics with the outcome of a game."""
+
+    def ensure_entry(team_obj):
+        team_name = getattr(team_obj, "name", "Team")
+        stats = results.setdefault("team_stats", {}).setdefault(
+            team_name,
+            {
+                "wins": 0,
+                "losses": 0,
+                "draws": 0,
+                "runs_scored": 0,
+                "runs_allowed": 0,
+                "games": 0,
+            },
+        )
+        return team_name, stats
+
+    home_name, home_stats = ensure_entry(game.home_team)
+    away_name, away_stats = ensure_entry(game.away_team)
+
+    home_stats["games"] += 1
+    away_stats["games"] += 1
+
+    if game.home_score > game.away_score:
+        home_stats["wins"] += 1
+        away_stats["losses"] += 1
+    elif game.away_score > game.home_score:
+        home_stats["losses"] += 1
+        away_stats["wins"] += 1
+    else:
+        home_stats["draws"] += 1
+        away_stats["draws"] += 1
+
+    home_stats["runs_scored"] += game.home_score
+    home_stats["runs_allowed"] += game.away_score
+    away_stats["runs_scored"] += game.away_score
+    away_stats["runs_allowed"] += game.home_score
+
+    aliases = results.get("team_aliases", {})
+    for alias, target in aliases.items():
+        if target == home_name:
+            results["team_stats"][alias] = home_stats
+        elif target == away_name:
+            results["team_stats"][alias] = away_stats
+
+
+__all__ = ["reset_team_and_players", "update_statistics"]

--- a/baseball_sim/interface/league_setup.py
+++ b/baseball_sim/interface/league_setup.py
@@ -1,0 +1,204 @@
+"""Utilities for preparing teams and schedules for league simulations."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, Optional, Sequence, Tuple
+
+from baseball_sim.config import get_project_paths, setup_project_environment
+from baseball_sim.infrastructure.logging_utils import logger as root_logger
+
+setup_project_environment()
+PATHS = get_project_paths()
+LOGGER = root_logger.getChild("interface.league_setup")
+
+
+@dataclass
+class TeamContext:
+    """Per-team state that needs to persist across games in a league."""
+
+    team: object
+    original_name: str
+    unique_name: str
+    pitcher_pool: List[object]
+    rotation: List[object]
+    rotation_index: int = 0
+
+    def next_starting_pitcher(self) -> Optional[object]:
+        pitcher = select_starting_pitcher(self.rotation, self.rotation_index)
+        if self.rotation:
+            self.rotation_index = (self.rotation_index + 1) % len(self.rotation)
+        return pitcher
+
+
+def get_pitcher_rotation(pitchers, preferred_rotation=None):
+    """Build a starting rotation list from the available pitchers."""
+
+    if not pitchers:
+        return []
+
+    if preferred_rotation:
+        rotation_list = []
+        seen = set()
+        for pitcher in preferred_rotation:
+            if pitcher and pitcher in pitchers and id(pitcher) not in seen:
+                rotation_list.append(pitcher)
+                seen.add(id(pitcher))
+        if rotation_list:
+            return rotation_list
+
+    starters = [
+        pitcher
+        for pitcher in pitchers
+        if getattr(pitcher, "pitcher_type", "").upper() == "SP"
+    ]
+
+    return list(starters)
+
+
+def select_starting_pitcher(rotation, index):
+    """Return the starting pitcher for a rotation index."""
+
+    if not rotation:
+        return None
+
+    safe_index = index % len(rotation)
+    return rotation[safe_index]
+
+
+def _assign_unique_team_names(contexts: Sequence[TeamContext]) -> None:
+    """Assign a unique name to each team when duplicates exist."""
+
+    totals: Dict[str, int] = defaultdict(int)
+    for ctx in contexts:
+        totals[ctx.original_name] += 1
+
+    counters: Dict[str, int] = defaultdict(int)
+    for ctx in contexts:
+        base = ctx.original_name
+        if totals[base] > 1:
+            counters[base] += 1
+            unique = f"{base}-{counters[base]}"
+        else:
+            unique = base
+        ctx.unique_name = unique
+        if hasattr(ctx.team, "name"):
+            ctx.team.name = unique
+
+
+def build_team_contexts(team_datas: Sequence[Mapping[str, object]]) -> List[TeamContext]:
+    """Create team contexts used to coordinate league simulations."""
+
+    if not team_datas:
+        raise ValueError("League simulation requires at least two teams.")
+
+    from baseball_sim.data.loader import DataLoader
+
+    player_data_path = PATHS.get_players_data_path()
+    player_data = DataLoader.load_json_data(player_data_path)
+
+    contexts: List[TeamContext] = []
+    for data in team_datas:
+        if not isinstance(data, Mapping):
+            raise ValueError("Each team configuration must be a mapping object.")
+        team_config = dict(data)
+        team, warnings = DataLoader.create_team(team_config, player_data=player_data)
+        for warning in warnings:
+            LOGGER.warning("Team setup warning: %s", warning)
+        try:
+            initial_lineup = list(getattr(team, "lineup", []) or [])
+            initial_positions = [getattr(p, "current_position", None) for p in initial_lineup]
+            setattr(team, "_initial_lineup", initial_lineup)
+            setattr(team, "_initial_lineup_positions", initial_positions)
+            setattr(team, "_initial_bench", list(getattr(team, "bench", []) or []))
+        except Exception:
+            pass
+        context = TeamContext(
+            team=team,
+            original_name=team_config.get("name", getattr(team, "name", "Team")),
+            unique_name=getattr(team, "name", "Team"),
+            pitcher_pool=list(team.pitchers),
+            rotation=get_pitcher_rotation(list(team.pitchers), getattr(team, "pitcher_rotation", None)),
+        )
+        contexts.append(context)
+
+    _assign_unique_team_names(contexts)
+    return contexts
+
+
+def initialize_league_results(
+    contexts: Sequence[TeamContext],
+    *,
+    role_assignment: Optional[Mapping[str, int]] = None,
+) -> Dict[str, object]:
+    """Initialise the shared results structure for a league run."""
+
+    results: Dict[str, object] = {
+        "games": [],
+        "team_stats": {},
+        "teams": {},
+        "meta": {},
+        "team_aliases": {},
+    }
+
+    for index, ctx in enumerate(contexts):
+        team = ctx.team
+        team_name = getattr(team, "name", f"Team {index + 1}")
+        original_name = ctx.original_name
+
+        results["teams"][team_name] = team
+        if original_name not in results["teams"]:
+            results["teams"][original_name] = team
+
+        if role_assignment:
+            for role, assigned_index in role_assignment.items():
+                if assigned_index != index:
+                    continue
+                results["teams"][role] = team
+                suffix = "Home" if role == "home" else "Away"
+                alias_name = f"{original_name} ({suffix})"
+                results["teams"][alias_name] = team
+                results["team_aliases"][alias_name] = team_name
+
+    return results
+
+
+def generate_round_robin_pairs(num_teams: int) -> List[List[Tuple[int, int]]]:
+    """Generate pairings for a round robin schedule with an even number of teams."""
+
+    if num_teams % 2 != 0:
+        raise ValueError("Team count must be even for league scheduling.")
+
+    if num_teams < 2:
+        return []
+
+    indices = list(range(num_teams))
+    half = num_teams // 2
+    rounds: List[List[Tuple[int, int]]] = []
+
+    for round_index in range(num_teams - 1):
+        pairs: List[Tuple[int, int]] = []
+        for i in range(half):
+            first = indices[i]
+            second = indices[-(i + 1)]
+            if round_index % 2 == 0:
+                home, away = first, second
+            else:
+                home, away = second, first
+            pairs.append((home, away))
+        rounds.append(pairs)
+
+        indices = [indices[0]] + [indices[-1]] + indices[1:-1]
+
+    return rounds
+
+
+__all__ = [
+    "TeamContext",
+    "build_team_contexts",
+    "generate_round_robin_pairs",
+    "get_pitcher_rotation",
+    "initialize_league_results",
+    "select_starting_pitcher",
+]

--- a/baseball_sim/ui/simulation_controls.py
+++ b/baseball_sim/ui/simulation_controls.py
@@ -6,7 +6,8 @@ from collections import Counter, defaultdict
 from copy import deepcopy
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
-from baseball_sim.interface.simulation import reset_team_and_players, simulate_games
+from baseball_sim.interface.game_management import reset_team_and_players
+from baseball_sim.interface.simulation import simulate_games
 from baseball_sim.data.team_library import TeamLibraryError
 
 from .exceptions import GameSessionError


### PR DESCRIPTION
## Summary
- extract team context and scheduling helpers into a new `league_setup` module
- move game reset and statistics utilities into an isolated `game_management` module
- introduce a `LeagueSimulator` coordinator and update `simulate_games` and UI imports to use the refactored structure

## Testing
- python -m compileall baseball_sim/interface

------
https://chatgpt.com/codex/tasks/task_e_68dfed21ef7c8322a6e8d479a526543c