### PR TITLE
Add shared rotation parsing helper

### DIFF
--- a/baseball_sim/data/loader.py
+++ b/baseball_sim/data/loader.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Tuple
 from baseball_sim.config import get_project_paths
 from baseball_sim.data.player import Player
 from baseball_sim.data.player_factory import PlayerFactory
+from baseball_sim.data.rotation_utils import parse_rotation_entries
 from baseball_sim.gameplay.team import Team
 from baseball_sim.infrastructure.logging_utils import log_error, logger as root_logger
 
@@ -70,16 +71,7 @@ class DataLoader:
     def setup_team_pitchers(team: Team, team_data: Dict, players_dict: Dict[str, Player]) -> None:
         """チームの投手陣をセットアップ"""
         rotation_raw = team_data.get("rotation")
-        rotation_names = []
-        if isinstance(rotation_raw, list):
-            for entry in rotation_raw:
-                if isinstance(entry, dict):
-                    name_value = entry.get("name")
-                else:
-                    name_value = entry
-                name = str(name_value or "").strip()
-                if name:
-                    rotation_names.append(name)
+        rotation_names = parse_rotation_entries(rotation_raw)
 
         for pitcher_name in team_data["pitchers"]:
             team.add_pitcher(players_dict[pitcher_name])

--- a/baseball_sim/data/rotation_utils.py
+++ b/baseball_sim/data/rotation_utils.py
@@ -1,0 +1,31 @@
+"""Utilities for working with pitcher rotation data."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+
+def parse_rotation_entries(raw_rotation: object) -> List[str]:
+    """Extract trimmed pitcher names from rotation entries.
+
+    The rotation data can contain either string names or dictionaries with a
+    ``name`` field. Any other values are ignored. Empty names are filtered out
+    after stripping surrounding whitespace.
+    """
+
+    if not isinstance(raw_rotation, Iterable) or isinstance(raw_rotation, (str, bytes)):
+        return []
+
+    names: List[str] = []
+    for entry in raw_rotation:
+        if isinstance(entry, dict):
+            name_value = entry.get("name")
+        else:
+            name_value = entry
+        name = str(name_value or "").strip()
+        if name:
+            names.append(name)
+    return names
+
+
+__all__ = ["parse_rotation_entries"]


### PR DESCRIPTION
## Summary
- add a rotation parsing helper to normalise rotation entries across modules
- use the helper when building team rotations in the data loader and team library
- keep validation for rotation entries in the team library while reusing the shared parser

## Testing
- python -m compileall baseball_sim/data

------
https://chatgpt.com/codex/tasks/task_e_68e00651230483228c142b8d34b38c7c