### PR TITLE
Extract iter_unique_teams helper into shared interface utils

### DIFF
--- a/baseball_sim/interface/simulation.py
+++ b/baseball_sim/interface/simulation.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterable, Mapping, Optional, Sequence
+from typing import Dict, Mapping, Optional, Sequence
 
 from baseball_sim.config import get_project_paths, setup_project_environment
 from baseball_sim.gameplay.game import GameState
@@ -20,6 +20,7 @@ from baseball_sim.interface.league_setup import (
     generate_round_robin_pairs,
     initialize_league_results,
 )
+from baseball_sim.interface.utils import iter_unique_teams
 
 setup_project_environment()
 PATHS = get_project_paths()
@@ -159,23 +160,6 @@ class LeagueSimulator:
             cards_per_opponent=1,
             role_assignment={"home": 0, "away": 1},
         )
-
-
-def _iter_unique_teams(results: Mapping[str, object]) -> Iterable[object]:
-    """結果に含まれる重複しないチームオブジェクトを列挙する"""
-
-    teams = results.get("teams") or {}
-    seen_ids: set[int] = set()
-    for team in teams.values():
-        if team is None:
-            continue
-        identifier = id(team)
-        if identifier in seen_ids:
-            continue
-        seen_ids.add(identifier)
-        yield team
-
-
 def simulate_games(
     num_games=10,
     output_file=None,
@@ -522,4 +506,9 @@ def simulate_single_game(game):
     return game_result
 
 
-__all__ = ["LeagueSimulator", "simulate_games", "simulate_single_game"]
+__all__ = [
+    "LeagueSimulator",
+    "simulate_games",
+    "simulate_single_game",
+    "iter_unique_teams",
+]

--- a/baseball_sim/interface/utils.py
+++ b/baseball_sim/interface/utils.py
@@ -1,0 +1,23 @@
+"""Utility helpers for interface-related modules."""
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+
+def iter_unique_teams(results: Mapping[str, object]) -> Iterable[object]:
+    """Yield unique team objects present in the results mapping."""
+
+    teams = results.get("teams") or {}
+    seen_ids: set[int] = set()
+    for team in teams.values():
+        if team is None:
+            continue
+        identifier = id(team)
+        if identifier in seen_ids:
+            continue
+        seen_ids.add(identifier)
+        yield team
+
+
+__all__ = ["iter_unique_teams"]

--- a/baseball_sim/ui/simulation_summary.py
+++ b/baseball_sim/ui/simulation_summary.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any, Dict, Iterable, List, Mapping, Optional
 
 from baseball_sim.gameplay.statistics import StatsCalculator
+from baseball_sim.interface.utils import iter_unique_teams
 
 
 def summarize_simulation_results(
@@ -22,7 +23,7 @@ def summarize_simulation_results(
     team_stats = results.get("team_stats") or {}
     alias_map = results.get("team_aliases") or {}
 
-    unique_teams = list(_iter_unique_teams(results))
+    unique_teams = list(iter_unique_teams(results))
     simulation_key_map = {id(team): f"sim-team-{index + 1}" for index, team in enumerate(unique_teams)}
     league_mode = bool(league) or len(unique_teams) > 2
 
@@ -113,26 +114,6 @@ def summarize_simulation_results(
         "aliases": alias_map,
         "roles": role_map,
     }
-
-
-def _iter_unique_teams(results: Mapping[str, Any]) -> Iterable[object]:
-    """Yield unique team objects present in the results.
-
-    Mirrors the logic in `interface/simulation._iter_unique_teams` but kept
-    locally to avoid tight coupling and import cycles between UI and core.
-    """
-    teams = results.get("teams") or {}
-    seen_ids: set[int] = set()
-    for team in teams.values():
-        if team is None:
-            continue
-        identifier = id(team)
-        if identifier in seen_ids:
-            continue
-        seen_ids.add(identifier)
-        yield team
-
-
 def _extract_team_objects(results: Mapping[str, Any]) -> Mapping[str, object]:
     raw = results.get("teams") or {}
     named = {}


### PR DESCRIPTION
## Summary
- move the unique team iteration helper into a shared `baseball_sim.interface.utils` module and expose it via `__all__`
- update the simulation and UI layers to import the shared helper and remove duplicate local implementations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e009809cf0832289309580b22bc339