### PR TITLE
Restrict pitcher editor to selected team

### DIFF
--- a/baseball_sim/ui/static/js/controllers/events.js
+++ b/baseball_sim/ui/static/js/controllers/events.js
@@ -53,6 +53,8 @@ import {
   isTitleEditorOpen,
   getTitleEditorTab,
   getTitleEditorView,
+  lockTitleEditorTeam,
+  clearTitleEditorLock,
   resetTitleEditorState,
 } from '../ui/titleLineup.js';
 import { escapeHtml, renderPositionList, renderPositionToken } from '../utils.js';
@@ -3729,6 +3731,7 @@ export function initEventListeners(actions) {
         const teamKey = openPitcherEditor.dataset.team || '';
         const normalizedTeam = teamKey === 'home' ? 'home' : teamKey === 'away' ? 'away' : null;
         if (!normalizedTeam) return;
+        lockTitleEditorTeam(normalizedTeam);
         setTitleEditorTab(normalizedTeam, 'pitcher');
         setTitleEditorOpen(normalizedTeam, true);
         setUIView('title-pitcher-editor');
@@ -3872,6 +3875,7 @@ export function initEventListeners(actions) {
         } else {
           resetTitleEditorState();
         }
+        clearTitleEditorLock();
         setUIView('title');
         renderTitle(stateCache.data?.title || {});
         updateScreenVisibility();
@@ -3890,6 +3894,7 @@ export function initEventListeners(actions) {
         if (select) {
           select.value = pitcherOption.dataset.pitcher || '';
         }
+        lockTitleEditorTeam(normalizedTeam);
         setTitleEditorTab(normalizedTeam, 'pitcher');
         setTitleEditorOpen(normalizedTeam, true);
         renderTitle(stateCache.data?.title || {});


### PR DESCRIPTION
## Summary
- prevent switching to the other team when the pitcher editor is opened from a team card
- clear the editor lock when leaving the pitcher editor so only the intended team is editable

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e238a306348322b689bccde242d831