### PR TITLE
Improve starter selection UI on title screen

### DIFF
--- a/baseball_sim/ui/static/css/layout.css
+++ b/baseball_sim/ui/static/css/layout.css
@@ -2540,6 +2540,12 @@
   gap: 12px;
 }
 
+.title-pitcher-hint {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
 .title-pitcher-option {
   display: flex;
   flex-direction: column;
@@ -2606,15 +2612,42 @@
   gap: 6px;
 }
 
+.title-pitcher-option-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.title-pitcher-option-button {
+  padding: 6px 14px;
+  font-size: 13px;
+  border-radius: 999px;
+  letter-spacing: 0.04em;
+}
+
+.title-pitcher-option-button.primary {
+  background: rgba(59, 130, 246, 0.2);
+  border: 1px solid rgba(96, 165, 250, 0.45);
+  color: var(--text-strong);
+}
+
+.title-pitcher-option-button.primary:hover:not(:disabled),
+.title-pitcher-option-button.primary:focus-visible {
+  outline: none;
+  background: rgba(59, 130, 246, 0.32);
+  border-color: rgba(96, 165, 250, 0.75);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
+}
+
+.title-pitcher-option-button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
 .title-pitcher-empty {
   font-size: 13px;
   color: var(--text-muted);
-}
-
-.title-pitcher-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
 }
 
 .title-lineup-chip,
@@ -2636,49 +2669,6 @@
   border-style: dashed;
 }
 
-.title-pitcher-select {
-  flex: 1;
-  border-radius: 10px;
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  background: rgba(10, 18, 34, 0.9);
-  color: var(--text);
-  font-size: 14px;
-  padding: 9px 12px;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.title-pitcher-select:focus-visible {
-  outline: none;
-  border-color: rgba(96, 165, 250, 0.75);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
-}
-
-.title-pitcher-select:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.title-pitcher-apply {
-  border-radius: 999px;
-  padding: 8px 16px;
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(30, 58, 138, 0.45);
-  color: var(--text-strong);
-  transition: background 0.2s ease, border-color 0.2s ease;
-}
-
-.title-pitcher-apply:hover:not(:disabled) {
-  border-color: rgba(148, 163, 184, 0.6);
-  background: rgba(30, 64, 175, 0.58);
-}
-
-.title-pitcher-apply:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
 
 
 .title-hint {

--- a/baseball_sim/ui/static/js/state.js
+++ b/baseball_sim/ui/static/js/state.js
@@ -13,6 +13,7 @@ export const stateCache = {
   abilitiesView: { team: 'away', type: 'batting' },
   uiView: 'lobby',
   titlePitcherReview: { team: null, pitcher: null },
+  titlePitcherSelection: { home: null, away: null },
   analytics: { running: false, samples: 0, sequence: null, offense: null, result: null, timestamp: null },
   analyticsPending: false,
   // Probability view state
@@ -157,6 +158,53 @@ function ensureSimulationRankingsState() {
 export function setUIView(view) {
   if (!view) return;
   stateCache.uiView = view;
+}
+
+function normalizeTeamKey(teamKey) {
+  return teamKey === 'home' ? 'home' : teamKey === 'away' ? 'away' : null;
+}
+
+function ensureTitlePitcherSelectionState() {
+  if (!stateCache.titlePitcherSelection || typeof stateCache.titlePitcherSelection !== 'object') {
+    stateCache.titlePitcherSelection = { home: null, away: null };
+  }
+  const selection = stateCache.titlePitcherSelection;
+  ['home', 'away'].forEach((team) => {
+    const value = selection[team];
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      selection[team] = trimmed || null;
+    } else if (value !== null) {
+      selection[team] = null;
+    }
+  });
+  return selection;
+}
+
+export function getTitlePitcherSelection(teamKey) {
+  const normalizedTeam = normalizeTeamKey(teamKey);
+  if (!normalizedTeam) return null;
+  const selection = ensureTitlePitcherSelectionState();
+  const value = selection[normalizedTeam];
+  return typeof value === 'string' && value ? value : null;
+}
+
+export function setTitlePitcherSelection(teamKey, pitcherName) {
+  const normalizedTeam = normalizeTeamKey(teamKey);
+  if (!normalizedTeam) return;
+  const selection = ensureTitlePitcherSelectionState();
+  const text = typeof pitcherName === 'string' ? pitcherName.trim() : '';
+  selection[normalizedTeam] = text || null;
+}
+
+export function clearTitlePitcherSelection(teamKey = null) {
+  const selection = ensureTitlePitcherSelectionState();
+  if (teamKey === 'home' || teamKey === 'away') {
+    selection[teamKey] = null;
+  } else {
+    selection.home = null;
+    selection.away = null;
+  }
 }
 
 export function setSimulationResultsView(view) {

--- a/baseball_sim/ui/templates/index.html
+++ b/baseball_sim/ui/templates/index.html
@@ -1386,12 +1386,9 @@
                   >
                     <div class="title-pitcher-panel">
                       <div class="title-pitcher-list" data-title-pitcher-list="away"></div>
-                      <div class="title-pitcher-actions">
-                        <select class="title-pitcher-select" data-team="away"></select>
-                        <button type="button" class="title-pitcher-apply" data-action="apply-pitcher" data-team="away">
-                          先発を設定
-                        </button>
-                      </div>
+                      <p class="title-pitcher-hint">
+                        候補の投手カードをクリックするとハイライトされ、各カードの「先発に設定」から確定できます。
+                      </p>
                     </div>
                   </section>
                 </div>
@@ -1407,12 +1404,9 @@
                   >
                     <div class="title-pitcher-panel">
                       <div class="title-pitcher-list" data-title-pitcher-list="home"></div>
-                      <div class="title-pitcher-actions">
-                        <select class="title-pitcher-select" data-team="home"></select>
-                        <button type="button" class="title-pitcher-apply" data-action="apply-pitcher" data-team="home">
-                          先発を設定
-                        </button>
-                      </div>
+                      <p class="title-pitcher-hint">
+                        候補の投手カードをクリックするとハイライトされ、各カードの「先発に設定」から確定できます。
+                      </p>
                     </div>
                   </section>
                 </div>


### PR DESCRIPTION
## Summary
- replace the pitcher dropdown on the team status editor with interactive cards that mirror the team management flow
- track the highlighted selection in UI state and reuse the existing confirmation modal from each card
- refresh styling and guidance text for the new starter selection controls

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e2529ca7288322a26b0c05284f2efc